### PR TITLE
Opcode Trace Middleware & Protected Globals Middleware

### DIFF
--- a/exec-service-wasmer/Cargo.toml
+++ b/exec-service-wasmer/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2021"
 [dependencies]
 elrond-exec-service = { path = "../exec-service" }
 
-wasmer = { git = "https://github.com/ElrondNetwork/wasmer", branch = "feat/wasmer2", default-features = false, features = [
+wasmer = { git = "https://github.com/ElrondNetwork/wasmer", rev = "411320b9a", default-features = false, features = [
     "singlepass",
     "sys",
     "universal",
     "wat",
 ] }
-wasmer-types = { git = "https://github.com/ElrondNetwork/wasmer", branch = "feat/wasmer2" }
+wasmer-types = { git = "https://github.com/ElrondNetwork/wasmer", rev = "411320b9a" }
 
 loupe = "0.1.3"

--- a/exec-service-wasmer/Cargo.toml
+++ b/exec-service-wasmer/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2021"
 [dependencies]
 elrond-exec-service = { path = "../exec-service" }
 
-wasmer = { git = "https://github.com/ElrondNetwork/wasmer", branch = "instance-reset", default-features = false, features = [
+wasmer = { git = "https://github.com/ElrondNetwork/wasmer", branch = "feat/wasmer2", default-features = false, features = [
     "singlepass",
     "sys",
     "universal",
     "wat",
 ] }
-wasmer-types = { git = "https://github.com/ElrondNetwork/wasmer", branch = "instance-reset" }
+wasmer-types = { git = "https://github.com/ElrondNetwork/wasmer", branch = "feat/wasmer2" }
 
 loupe = "0.1.3"

--- a/exec-service-wasmer/src/lib.rs
+++ b/exec-service-wasmer/src/lib.rs
@@ -6,6 +6,7 @@ mod wasmer_instance;
 mod wasmer_metering;
 mod wasmer_metering_helpers;
 mod wasmer_opcode_control;
+mod wasmer_opcode_tracer;
 mod wasmer_service;
 mod wasmer_vm_hooks;
 

--- a/exec-service-wasmer/src/lib.rs
+++ b/exec-service-wasmer/src/lib.rs
@@ -6,7 +6,8 @@ mod wasmer_instance;
 mod wasmer_metering;
 mod wasmer_metering_helpers;
 mod wasmer_opcode_control;
-mod wasmer_opcode_tracer;
+mod wasmer_protected_globals;
+mod wasmer_opcode_trace;
 mod wasmer_service;
 mod wasmer_vm_hooks;
 

--- a/exec-service-wasmer/src/wasmer_instance.rs
+++ b/exec-service-wasmer/src/wasmer_instance.rs
@@ -1,3 +1,4 @@
+use crate::wasmer_opcode_tracer::OpcodeTracer;
 use crate::{
     wasmer_breakpoints::*, wasmer_imports::generate_import_object, wasmer_metering::*,
     wasmer_opcode_control::OpcodeControl, wasmer_vm_hooks::VMHooksWrapper, WasmerExecutorData,
@@ -127,6 +128,9 @@ fn push_middlewares(
     compilation_options: &CompilationOptions,
     executor_data: Rc<WasmerExecutorData>,
 ) {
+    // Create opcode_tracer middleware
+    let opcode_tracer_middleware = Arc::new(OpcodeTracer::new());
+
     // Create breakpoints middleware
     let breakpoints_middleware = Arc::new(Breakpoints::new());
 
@@ -151,6 +155,11 @@ fn push_middlewares(
     compiler.push_middleware(metering_middleware);
     executor_data.print_execution_info("Adding breakpoints middleware ...");
     compiler.push_middleware(breakpoints_middleware);
+
+    if compilation_options.opcode_trace {
+        executor_data.print_execution_info("Adding opcode_tracer middleware ...");
+        compiler.push_middleware(opcode_tracer_middleware);
+    }
 }
 
 impl Instance for WasmerInstance {

--- a/exec-service-wasmer/src/wasmer_instance.rs
+++ b/exec-service-wasmer/src/wasmer_instance.rs
@@ -129,9 +129,6 @@ fn push_middlewares(
     compilation_options: &CompilationOptions,
     executor_data: Rc<WasmerExecutorData>,
 ) {
-    // Create opcode_tracer middleware
-    let opcode_tracer_middleware = Arc::new(OpcodeTracer::new());
-
     // Create breakpoints middleware
     let breakpoints_middleware = Arc::new(Breakpoints::new());
 
@@ -164,6 +161,8 @@ fn push_middlewares(
     compiler.push_middleware(breakpoints_middleware);
 
     if compilation_options.opcode_trace {
+        // Create opcode_tracer middleware
+        let opcode_tracer_middleware = Arc::new(OpcodeTracer::new());
         executor_data.print_execution_info("Adding opcode_tracer middleware ...");
         compiler.push_middleware(opcode_tracer_middleware);
     }

--- a/exec-service-wasmer/src/wasmer_metering.rs
+++ b/exec-service-wasmer/src/wasmer_metering.rs
@@ -160,11 +160,16 @@ impl FunctionMiddleware for FunctionMetering {
         // corner cases.
         self.accumulated_cost += get_opcode_cost(&operator, &self.opcode_cost) as u64;
 
+        println!("{:#?}", operator);
+
         if matches!(
             operator,
             Operator::Loop { .. }
+                | Operator::Block { .. }
                 | Operator::End
+                | Operator::If { .. }
                 | Operator::Else
+                | Operator::Unreachable
                 | Operator::Br { .. }
                 | Operator::BrTable { .. }
                 | Operator::BrIf { .. }

--- a/exec-service-wasmer/src/wasmer_metering.rs
+++ b/exec-service-wasmer/src/wasmer_metering.rs
@@ -160,8 +160,6 @@ impl FunctionMiddleware for FunctionMetering {
         // corner cases.
         self.accumulated_cost += get_opcode_cost(&operator, &self.opcode_cost) as u64;
 
-        println!("{:#?}", operator);
-
         if matches!(
             operator,
             Operator::Loop { .. }

--- a/exec-service-wasmer/src/wasmer_metering.rs
+++ b/exec-service-wasmer/src/wasmer_metering.rs
@@ -160,8 +160,6 @@ impl FunctionMiddleware for FunctionMetering {
         // corner cases.
         self.accumulated_cost += get_opcode_cost(&operator, &self.opcode_cost) as u64;
 
-        // println!("metering op: {:#?}", &operator);
-
         if matches!(
             operator,
             Operator::Loop { .. }

--- a/exec-service-wasmer/src/wasmer_metering.rs
+++ b/exec-service-wasmer/src/wasmer_metering.rs
@@ -160,6 +160,8 @@ impl FunctionMiddleware for FunctionMetering {
         // corner cases.
         self.accumulated_cost += get_opcode_cost(&operator, &self.opcode_cost) as u64;
 
+        // println!("metering op: {:#?}", &operator);
+
         if matches!(
             operator,
             Operator::Loop { .. }

--- a/exec-service-wasmer/src/wasmer_opcode_tracer.rs
+++ b/exec-service-wasmer/src/wasmer_opcode_tracer.rs
@@ -1,0 +1,76 @@
+use loupe::{MemoryUsage, MemoryUsageTracker};
+use std::fs::File;
+use std::io::Write;
+use std::mem;
+use wasmer::wasmparser::Operator;
+use wasmer::{
+    FunctionMiddleware, LocalFunctionIndex, MiddlewareError, MiddlewareReaderState,
+    ModuleMiddleware,
+};
+use wasmer_types::ModuleInfo;
+
+const OPCODE_TRACE_PATH: &str = "opcode.trace2";
+
+#[derive(Debug)]
+pub(crate) struct OpcodeTracer {}
+
+impl OpcodeTracer {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+}
+
+unsafe impl Send for OpcodeTracer {}
+unsafe impl Sync for OpcodeTracer {}
+
+impl MemoryUsage for OpcodeTracer {
+    fn size_of_val(&self, _tracker: &mut dyn MemoryUsageTracker) -> usize {
+        mem::size_of_val(self)
+    }
+}
+
+impl ModuleMiddleware for OpcodeTracer {
+    fn generate_function_middleware(
+        &self,
+        _local_function_index: LocalFunctionIndex,
+    ) -> Box<dyn FunctionMiddleware> {
+        Box::new(FunctionOpcodeTracer {
+            output_file: File::create(OPCODE_TRACE_PATH).unwrap(),
+        })
+    }
+
+    fn transform_module_info(&self, _module_info: &mut ModuleInfo) {}
+}
+
+#[derive(Debug)]
+struct FunctionOpcodeTracer {
+    output_file: File,
+}
+
+impl FunctionOpcodeTracer {
+    fn trace_opcode<'b>(&mut self, operator: &Operator<'b>) -> Result<(), MiddlewareError> {
+        let result = write!(self.output_file, "\t{:?}\n", operator);
+        if let Err(error) = result {
+            return Err(MiddlewareError::new(
+                "opcode_trace_middleware",
+                error.to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+impl FunctionMiddleware for FunctionOpcodeTracer {
+    fn feed<'b>(
+        &mut self,
+        operator: Operator<'b>,
+        state: &mut MiddlewareReaderState<'b>,
+    ) -> Result<(), MiddlewareError> {
+        self.trace_opcode(&operator)?;
+
+        state.push_operator(operator);
+
+        Ok(())
+    }
+}

--- a/exec-service-wasmer/src/wasmer_opcode_tracer.rs
+++ b/exec-service-wasmer/src/wasmer_opcode_tracer.rs
@@ -49,7 +49,7 @@ struct FunctionOpcodeTracer {
 
 impl FunctionOpcodeTracer {
     fn trace_opcode<'b>(&mut self, operator: &Operator<'b>) -> Result<(), MiddlewareError> {
-        let result = write!(self.output_file, "\t{:?}\n", operator);
+        let result = writeln!(self.output_file, "\t{:?}", operator);
         if let Err(error) = result {
             return Err(MiddlewareError::new(
                 "opcode_trace_middleware",

--- a/exec-service-wasmer/src/wasmer_protected_globals.rs
+++ b/exec-service-wasmer/src/wasmer_protected_globals.rs
@@ -1,0 +1,90 @@
+use std::{mem, sync::Arc};
+
+use loupe::{MemoryUsage, MemoryUsageTracker};
+use wasmer::{
+    wasmparser::Operator, FunctionMiddleware, LocalFunctionIndex, MiddlewareError,
+    MiddlewareReaderState, ModuleMiddleware,
+};
+use wasmer_types::ModuleInfo;
+
+use crate::wasmer_helpers::MiddlewareWithProtectedGlobals;
+
+#[derive(Debug)]
+pub(crate) struct ProtectedGlobals {
+    protected_middlewares: Vec<Arc<dyn MiddlewareWithProtectedGlobals>>,
+}
+
+impl ProtectedGlobals {
+    pub(crate) fn new(protected_middlewares: Vec<Arc<dyn MiddlewareWithProtectedGlobals>>) -> Self {
+        Self {
+            protected_middlewares,
+        }
+    }
+
+    fn get_protected_globals(&self) -> Vec<u32> {
+        let mut protected_globals = vec![];
+        for middleware in &self.protected_middlewares {
+            protected_globals.extend(middleware.protected_globals())
+        }
+        protected_globals
+    }
+}
+
+unsafe impl Send for ProtectedGlobals {}
+unsafe impl Sync for ProtectedGlobals {}
+
+impl MemoryUsage for ProtectedGlobals {
+    fn size_of_val(&self, _tracker: &mut dyn MemoryUsageTracker) -> usize {
+        mem::size_of_val(self)
+    }
+}
+
+impl ModuleMiddleware for ProtectedGlobals {
+    fn generate_function_middleware(
+        &self,
+        _local_function_index: LocalFunctionIndex,
+    ) -> Box<dyn FunctionMiddleware> {
+        Box::new(FunctionProtectedGlobals {
+            protected_globals: self.get_protected_globals(),
+        })
+    }
+
+    fn transform_module_info(&self, _module_info: &mut ModuleInfo) {}
+}
+
+#[derive(Debug)]
+struct FunctionProtectedGlobals {
+    protected_globals: Vec<u32>,
+}
+
+impl FunctionProtectedGlobals {
+    fn check_protected_globals_invalid_access<'b>(
+        &self,
+        operator: &Operator<'b>,
+    ) -> Result<(), MiddlewareError> {
+        if let Operator::GlobalSet { global_index } = *operator {
+            if self.protected_globals.contains(&global_index) {
+                return Err(MiddlewareError::new(
+                    "protected_globals_middleware",
+                    "protected globals invalid access",
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl FunctionMiddleware for FunctionProtectedGlobals {
+    fn feed<'b>(
+        &mut self,
+        operator: Operator<'b>,
+        state: &mut MiddlewareReaderState<'b>,
+    ) -> Result<(), MiddlewareError> {
+        self.check_protected_globals_invalid_access(&operator)?;
+
+        state.push_operator(operator);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
- change `Cargo.toml` to use commit hash instead of branch for better update
- add `protected_globals_middleware` -> this was started from `opcode_control_middleware` and solves our gas cost mismatches
- add `opcode_tracer_middleware`
- add missing ops in `metering_middleware` to correct gas cost

**PS: Sorting log lines for opcode_tracer will be addressed in another PR**