### PR TITLE
Logger redesign

### DIFF
--- a/exec-c-api/libvmexeccapi.h
+++ b/exec-c-api/libvmexeccapi.h
@@ -312,19 +312,6 @@ vm_exec_result_t vm_check_signatures(vm_exec_instance_t *instance_ptr);
 void vm_exec_executor_destroy(vm_exec_executor_t *executor);
 
 /**
- * Sets the log level for the given executor.
- *
- * This function returns `vm_exec_result_t::WASMER_OK` upon success,
- * `vm_exec_result_t::WASMER_ERROR` otherwise. You can use
- * `wasmer_last_error_message()` to get the generated error message.
- *
- * # Safety
- *
- * C API function, works with raw object pointers.
- */
-vm_exec_result_t vm_exec_executor_set_log_level(vm_exec_executor_t *executor_ptr, uint64_t value);
-
-/**
  * Sets the data that can be hold by an instance context.
  *
  * An instance context (represented by the opaque
@@ -575,6 +562,11 @@ vm_exec_result_t vm_exec_new_instance(vm_exec_executor_t *executor_ptr,
                                       uint8_t *wasm_bytes_ptr,
                                       uint32_t wasm_bytes_len,
                                       const vm_exec_compilation_options_t *options_ptr);
+
+/**
+ * Sets the log level.
+ */
+vm_exec_result_t vm_exec_set_log_level(uint64_t value);
 
 /**
  * Sets the opcode costs for the given executor.

--- a/exec-c-api/src/capi_executor.rs
+++ b/exec-c-api/src/capi_executor.rs
@@ -79,33 +79,6 @@ pub unsafe extern "C" fn vm_exec_executor_set_vm_hooks_ptr(
     }
 }
 
-/// Sets the log level for the given executor.
-///
-/// This function returns `vm_exec_result_t::WASMER_OK` upon success,
-/// `vm_exec_result_t::WASMER_ERROR` otherwise. You can use
-/// `wasmer_last_error_message()` to get the generated error message.
-///
-/// # Safety
-///
-/// C API function, works with raw object pointers.
-#[allow(clippy::cast_ptr_alignment)]
-#[no_mangle]
-pub unsafe extern "C" fn vm_exec_executor_set_log_level(
-    executor_ptr: *mut vm_exec_executor_t,
-    value: u64,
-) -> vm_exec_result_t {
-    let capi_executor = cast_input_ptr!(executor_ptr, CapiExecutor, "executor ptr is null");
-
-    let result = capi_executor.content.set_execution_log_level(value);
-    match result {
-        Ok(()) => vm_exec_result_t::VM_EXEC_OK,
-        Err(message) => {
-            with_service(|service| service.update_last_error_str(message.to_string()));
-            vm_exec_result_t::VM_EXEC_ERROR
-        }
-    }
-}
-
 /// Destroys a VM executor object.
 ///
 /// # Safety

--- a/exec-c-api/src/capi_logger.rs
+++ b/exec-c-api/src/capi_logger.rs
@@ -4,7 +4,7 @@ use crate::{basic_types::vm_exec_result_t, service_singleton::with_service};
 
 /// Sets the log level.
 #[no_mangle]
-pub unsafe extern "C" fn vm_exec_set_log_level(value: u64) -> vm_exec_result_t {
+pub extern "C" fn vm_exec_set_log_level(value: u64) -> vm_exec_result_t {
     let result = u64_to_log_level(value);
 
     match result {

--- a/exec-c-api/src/capi_logger.rs
+++ b/exec-c-api/src/capi_logger.rs
@@ -1,0 +1,20 @@
+use multiversx_vm_executor_wasmer::{set_log_level, u64_to_log_level};
+
+use crate::{basic_types::vm_exec_result_t, service_singleton::with_service};
+
+/// Sets the log level.
+#[no_mangle]
+pub unsafe extern "C" fn vm_exec_set_log_level(value: u64) -> vm_exec_result_t {
+    let result = u64_to_log_level(value);
+
+    match result {
+        Ok(level) => {
+            set_log_level(level);
+            vm_exec_result_t::VM_EXEC_OK
+        }
+        Err(message) => {
+            with_service(|service| service.update_last_error_str(message.to_string()));
+            vm_exec_result_t::VM_EXEC_ERROR
+        }
+    }
+}

--- a/exec-c-api/src/lib.rs
+++ b/exec-c-api/src/lib.rs
@@ -7,6 +7,7 @@ pub mod capi_error;
 pub mod capi_executor;
 pub mod capi_instance;
 pub mod capi_instance_cache;
+pub mod capi_logger;
 pub mod capi_memory;
 pub mod capi_metering;
 pub mod capi_vm_hook_pointers;

--- a/exec-service-wasmer/Cargo.toml
+++ b/exec-service-wasmer/Cargo.toml
@@ -16,4 +16,6 @@ wasmer = { git = "https://github.com/multiversx/wasmer", rev = "244da9f49", defa
 ] }
 wasmer-types = { git = "https://github.com/multiversx/wasmer", rev = "244da9f49" }
 
+chrono = "0.4.23"
+log = "0.4.17"
 loupe = "0.1.3"

--- a/exec-service-wasmer/Cargo.toml
+++ b/exec-service-wasmer/Cargo.toml
@@ -8,13 +8,13 @@ edition = "2021"
 [dependencies]
 multiversx-vm-executor = { path = "../exec-service" }
 
-wasmer = { git = "https://github.com/multiversx/wasmer", rev = "244da9f49", default-features = false, features = [
+wasmer = { git = "https://github.com/multiversx/wasmer", rev = "b9f401730", default-features = false, features = [
     "singlepass",
     "sys",
     "universal",
     "wat",
 ] }
-wasmer-types = { git = "https://github.com/multiversx/wasmer", rev = "244da9f49" }
+wasmer-types = { git = "https://github.com/multiversx/wasmer", rev = "b9f401730" }
 
 chrono = "0.4.23"
 log = "0.4.17"

--- a/exec-service-wasmer/src/lib.rs
+++ b/exec-service-wasmer/src/lib.rs
@@ -3,6 +3,7 @@ mod wasmer_executor;
 mod wasmer_helpers;
 mod wasmer_imports;
 mod wasmer_instance;
+mod wasmer_logger;
 mod wasmer_metering;
 mod wasmer_metering_helpers;
 mod wasmer_opcode_control;

--- a/exec-service-wasmer/src/lib.rs
+++ b/exec-service-wasmer/src/lib.rs
@@ -14,5 +14,6 @@ mod wasmer_vm_hooks;
 
 pub use wasmer_executor::*;
 pub use wasmer_instance::*;
+pub use wasmer_logger::*;
 pub use wasmer_metering_helpers::*;
 pub use wasmer_service::*;

--- a/exec-service-wasmer/src/wasmer_executor.rs
+++ b/exec-service-wasmer/src/wasmer_executor.rs
@@ -1,101 +1,62 @@
+use crate::wasmer_logger as WasmerLogger;
 use crate::WasmerInstance;
+use log::trace;
 use multiversx_vm_executor::{
     CompilationOptions, Executor, ExecutorError, Instance, OpcodeCost, ServiceError, VMHooks,
 };
+use std::cell::RefCell;
 use std::ffi::c_void;
 use std::rc::Rc;
-use std::sync::Arc;
-
-pub struct WasmerExecutor {
-    pub data: Rc<WasmerExecutorData>,
-}
-
-#[derive(PartialEq, PartialOrd, Eq)]
-pub enum WasmerExecutorLogLevel {
-    None,
-    Debug,
-    Trace,
-}
-
-impl TryFrom<u64> for WasmerExecutorLogLevel {
-    type Error = &'static str;
-
-    fn try_from(value: u64) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(WasmerExecutorLogLevel::None),
-            1 => Ok(WasmerExecutorLogLevel::Debug),
-            2 => Ok(WasmerExecutorLogLevel::Trace),
-            _ => Err("WasmerExecutor undefined log level"),
-        }
-    }
-}
+use std::sync::{Arc, Mutex};
 
 pub struct WasmerExecutorData {
     pub vm_hooks: Rc<Box<dyn VMHooks>>,
-    pub opcode_cost: Arc<OpcodeCost>,
-    pub log_level: WasmerExecutorLogLevel,
+    pub opcode_cost: Arc<Mutex<OpcodeCost>>,
 }
 
 impl WasmerExecutorData {
-    pub(crate) fn debug(&self, message: &str) {
-        if self.log_level >= WasmerExecutorLogLevel::Debug {
-            println!("[DEBUG] {message}");
-        }
-    }
-    #[allow(dead_code)]
-    pub(crate) fn trace(&self, message: &str) {
-        if self.log_level == WasmerExecutorLogLevel::Trace {
-            println!("[TRACE] {message}");
-        }
-    }
-}
-
-impl Executor for WasmerExecutor {
     fn set_vm_hooks_ptr(&mut self, vm_hooks_ptr: *mut c_void) -> Result<(), ExecutorError> {
-        self.data.debug("Setting context pointer ...");
-        if let Some(data_mut) = Rc::get_mut(&mut self.data) {
-            if let Some(vm_hooks) = Rc::get_mut(&mut data_mut.vm_hooks) {
-                vm_hooks.set_vm_hooks_ptr(vm_hooks_ptr);
-                return Ok(());
-            }
+        if let Some(vm_hooks) = Rc::get_mut(&mut self.vm_hooks) {
+            vm_hooks.set_vm_hooks_ptr(vm_hooks_ptr);
+            return Ok(());
         }
 
         Err(Box::new(ServiceError::new(
-            "WasmerExecutor already has instances, can no longer be configured",
+            "WasmerExecutor already set vmhooks, further configuration not allowed",
         )))
     }
 
     fn set_opcode_cost(&mut self, opcode_cost: &OpcodeCost) -> Result<(), ExecutorError> {
-        self.data.debug("Setting opcode cost ...");
-        if let Some(data_mut) = Rc::get_mut(&mut self.data) {
-            if let Some(opcode_cost_mut) = Arc::get_mut(&mut data_mut.opcode_cost) {
-                *opcode_cost_mut = opcode_cost.clone();
-                return Ok(());
-            }
-        }
+        self.opcode_cost.lock().unwrap().clone_from(opcode_cost);
+        Ok(())
+    }
+}
 
-        Err(Box::new(ServiceError::new(
-            "WasmerExecutor opcodes cost configuration error",
-        )))
+pub struct WasmerExecutor {
+    pub data: Rc<RefCell<WasmerExecutorData>>,
+}
+
+impl Executor for WasmerExecutor {
+    fn set_vm_hooks_ptr(&mut self, vm_hooks_ptr: *mut c_void) -> Result<(), ExecutorError> {
+        trace!("Setting vmhooks ...");
+        self.data.borrow_mut().set_vm_hooks_ptr(vm_hooks_ptr)
+    }
+
+    fn set_opcode_cost(&mut self, opcode_cost: &OpcodeCost) -> Result<(), ExecutorError> {
+        trace!("Setting opcode cost...");
+        self.data.borrow_mut().set_opcode_cost(opcode_cost)
     }
 
     fn set_execution_log_level(&mut self, value: u64) -> Result<(), ExecutorError> {
-        if let Some(data_mut) = Rc::get_mut(&mut self.data) {
-            let result = WasmerExecutorLogLevel::try_from(value);
-            match result {
-                Ok(log_level) => {
-                    data_mut.log_level = log_level;
-                    return Ok(());
-                }
-                Err(error) => {
-                    return Err(Box::new(ServiceError::new(error)));
-                }
+        let result = WasmerLogger::u64_to_log_level(value);
+        match result {
+            Ok(level) => {
+                trace!("Setting execution log level to {level}...");
+                log::set_max_level(level);
+                Ok(())
             }
+            Err(error) => Err(Box::new(ServiceError::new(error))),
         }
-
-        Err(Box::new(ServiceError::new(
-            "WasmerExecutor log level error",
-        )))
     }
 
     fn new_instance(

--- a/exec-service-wasmer/src/wasmer_executor.rs
+++ b/exec-service-wasmer/src/wasmer_executor.rs
@@ -1,6 +1,6 @@
 use crate::wasmer_logger as WasmerLogger;
 use crate::WasmerInstance;
-use log::trace;
+use log::info;
 use multiversx_vm_executor::{
     CompilationOptions, Executor, ExecutorError, Instance, OpcodeCost, ServiceError, VMHooks,
 };
@@ -38,12 +38,12 @@ pub struct WasmerExecutor {
 
 impl Executor for WasmerExecutor {
     fn set_vm_hooks_ptr(&mut self, vm_hooks_ptr: *mut c_void) -> Result<(), ExecutorError> {
-        trace!("Setting vmhooks ...");
+        info!("Setting vmhooks ...");
         self.data.borrow_mut().set_vm_hooks_ptr(vm_hooks_ptr)
     }
 
     fn set_opcode_cost(&mut self, opcode_cost: &OpcodeCost) -> Result<(), ExecutorError> {
-        trace!("Setting opcode cost...");
+        info!("Setting opcode cost...");
         self.data.borrow_mut().set_opcode_cost(opcode_cost)
     }
 
@@ -51,7 +51,7 @@ impl Executor for WasmerExecutor {
         let result = WasmerLogger::u64_to_log_level(value);
         match result {
             Ok(level) => {
-                trace!("Setting execution log level to {level}...");
+                info!("Setting execution log level to {level}...");
                 log::set_max_level(level);
                 Ok(())
             }

--- a/exec-service-wasmer/src/wasmer_instance.rs
+++ b/exec-service-wasmer/src/wasmer_instance.rs
@@ -187,8 +187,14 @@ impl Instance for WasmerInstance {
             .map_err(|_| "function not found".to_string())?;
 
         match func.call(&[]) {
-            Ok(_) => Ok(()),
-            Err(err) => Err(err.to_string()),
+            Ok(_) => {
+                debug!("Call succeeded: {func_name}");
+                Ok(())
+            }
+            Err(err) => {
+                log::error!("Call failed: {func_name} - {err}");
+                Err(err.to_string())
+            }
         }
     }
 

--- a/exec-service-wasmer/src/wasmer_instance.rs
+++ b/exec-service-wasmer/src/wasmer_instance.rs
@@ -171,7 +171,7 @@ fn push_middlewares(
     if compilation_options.opcode_trace {
         // Create opcode_tracer middleware
         let opcode_tracer_middleware = Arc::new(OpcodeTracer::new());
-        // trace!("Adding opcode_tracer middleware ...");
+        trace!("Adding opcode_tracer middleware ...");
         compiler.push_middleware(opcode_tracer_middleware);
     }
 }

--- a/exec-service-wasmer/src/wasmer_logger.rs
+++ b/exec-service-wasmer/src/wasmer_logger.rs
@@ -15,7 +15,6 @@ impl log::Log for WasmerLogger {
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            const PATTERN: &str = "/";
             println!(
                 "{:<5}[{}] [{}]\t{}",
                 record.level(),
@@ -23,7 +22,7 @@ impl log::Log for WasmerLogger {
                 record
                     .file()
                     .unwrap()
-                    .rsplit_terminator(PATTERN)
+                    .rsplit_terminator('/')
                     .next()
                     .unwrap(),
                 record.args()

--- a/exec-service-wasmer/src/wasmer_logger.rs
+++ b/exec-service-wasmer/src/wasmer_logger.rs
@@ -44,6 +44,15 @@ pub fn init(log_level: LevelFilter) {
     });
 }
 
+pub fn set_log_level(log_level: LevelFilter) {
+    if INIT.is_completed() {
+        log::set_max_level(log_level);
+        info!("Setting log level to {log_level} ...");
+    } else {
+        init(log_level);
+    }
+}
+
 pub fn u64_to_log_level(value: u64) -> Result<LevelFilter, &'static str> {
     match value {
         0 => Ok(LevelFilter::Off),

--- a/exec-service-wasmer/src/wasmer_logger.rs
+++ b/exec-service-wasmer/src/wasmer_logger.rs
@@ -1,0 +1,111 @@
+use chrono::Local;
+
+use log::{info, Level, LevelFilter, Metadata, Record};
+
+struct WasmerLogger;
+
+impl log::Log for WasmerLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= Level::Trace
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            println!(
+                "{}[{}] [{}]\t{}",
+                record.level(),
+                Local::now().format("%Y-%m-%d %H:%M:%S:%3f"),
+                record
+                    .file()
+                    .unwrap()
+                    .rsplit_terminator("/")
+                    .next()
+                    .unwrap(),
+                record.args()
+            );
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+pub fn init(log_level: LevelFilter) -> bool {
+    let result =
+        log::set_boxed_logger(Box::new(WasmerLogger)).map(|()| log::set_max_level(log_level));
+
+    match result {
+        Ok(_) => {
+            let log_level = log::max_level();
+            info!("Initializing WasmerLogger with {log_level} ...");
+            true
+        }
+        Err(_) => {
+            info!("WasmerLogger already initialized");
+            false
+        }
+    }
+}
+
+pub fn u64_to_log_level(value: u64) -> Result<LevelFilter, &'static str> {
+    match value {
+        0 => Ok(LevelFilter::Off),
+        1 => Ok(LevelFilter::Error),
+        2 => Ok(LevelFilter::Warn),
+        3 => Ok(LevelFilter::Info),
+        4 => Ok(LevelFilter::Debug),
+        5 => Ok(LevelFilter::Trace),
+        _ => Err("Undefined log level"),
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+
+    #[test]
+    fn test_already_initialized() {
+        let result = init(LevelFilter::Off);
+        assert!(result);
+        let result = init(LevelFilter::Off);
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_set_max_log_level() {
+        init(LevelFilter::Off);
+        assert_eq!(log::max_level(), LevelFilter::Off);
+
+        log::set_max_level(LevelFilter::Debug);
+        assert_eq!(log::max_level(), LevelFilter::Debug);
+    }
+
+    #[test]
+    fn test_u64_to_log_level() {
+        let result = u64_to_log_level(0);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), LevelFilter::Off);
+
+        let result = u64_to_log_level(1);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), LevelFilter::Error);
+
+        let result = u64_to_log_level(2);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), LevelFilter::Warn);
+
+        let result = u64_to_log_level(3);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), LevelFilter::Info);
+
+        let result = u64_to_log_level(4);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), LevelFilter::Debug);
+
+        let result = u64_to_log_level(5);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), LevelFilter::Trace);
+
+        let result = u64_to_log_level(6);
+        assert!(result.is_err());
+    }
+}

--- a/exec-service-wasmer/src/wasmer_metering.rs
+++ b/exec-service-wasmer/src/wasmer_metering.rs
@@ -26,7 +26,7 @@ struct MeteringGlobalIndexes {
 pub(crate) struct Metering {
     points_limit: u64,
     unmetered_locals: usize,
-    opcode_cost: Arc<OpcodeCost>,
+    opcode_cost: Arc<Mutex<OpcodeCost>>,
     breakpoints_middleware: Arc<Breakpoints>,
     global_indexes: Mutex<Option<MeteringGlobalIndexes>>,
 }
@@ -35,7 +35,7 @@ impl Metering {
     pub(crate) fn new(
         points_limit: u64,
         unmetered_locals: usize,
-        opcode_cost: Arc<OpcodeCost>,
+        opcode_cost: Arc<Mutex<OpcodeCost>>,
         breakpoints_middleware: Arc<Breakpoints>,
     ) -> Self {
         Self {
@@ -119,7 +119,7 @@ impl MiddlewareWithProtectedGlobals for Metering {
 struct FunctionMetering {
     accumulated_cost: u64,
     unmetered_locals: usize,
-    opcode_cost: Arc<OpcodeCost>,
+    opcode_cost: Arc<Mutex<OpcodeCost>>,
     breakpoints_middleware: Arc<Breakpoints>,
     global_indexes: MeteringGlobalIndexes,
 }
@@ -164,7 +164,8 @@ impl FunctionMiddleware for FunctionMetering {
         // Get the cost of the current operator, and add it to the accumulator.
         // This needs to be done before the metering logic, to prevent operators like `Call` from escaping metering in some
         // corner cases.
-        self.accumulated_cost += get_opcode_cost(&operator, &self.opcode_cost) as u64;
+        self.accumulated_cost +=
+            get_opcode_cost(&operator, &self.opcode_cost.lock().unwrap()) as u64;
 
         if matches!(
             operator,
@@ -198,7 +199,7 @@ impl FunctionMiddleware for FunctionMetering {
         let unmetered_locals = self.unmetered_locals as u32;
         if count > unmetered_locals {
             let metered_locals = count - unmetered_locals;
-            let local_cost = get_local_cost(&self.opcode_cost);
+            let local_cost = get_local_cost(&self.opcode_cost.lock().unwrap());
             let metered_locals_cost = metered_locals * local_cost;
             self.accumulated_cost += metered_locals_cost as u64;
         }

--- a/exec-service-wasmer/src/wasmer_service.rs
+++ b/exec-service-wasmer/src/wasmer_service.rs
@@ -2,8 +2,8 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use log::info;
 use log::LevelFilter;
-use log::trace;
 use multiversx_vm_executor::{
     Executor, ExecutorError, ExecutorLastError, ExecutorService, VMHooks,
 };
@@ -19,12 +19,15 @@ pub struct BasicExecutorService {
 
 impl BasicExecutorService {
     pub fn new() -> Self {
-        // Initiliaze the logger only once
-        WasmerLogger::init(LevelFilter::Trace);
-
+        Self::init();
         Self {
             last_error: String::new(),
         }
+    }
+
+    fn init() {
+        // Initialize the logger only once
+        WasmerLogger::init(LevelFilter::Trace);
     }
 }
 
@@ -43,7 +46,7 @@ impl ExecutorService for BasicExecutorService {
         &self,
         vm_hooks_builder: Box<dyn VMHooks>,
     ) -> Result<Box<dyn Executor>, ExecutorError> {
-        trace!("Creating new executor ...");
+        info!("Initializing WasmerExecutor ...");
 
         let data = WasmerExecutorData {
             vm_hooks: Rc::new(vm_hooks_builder),

--- a/exec-service/src/executor.rs
+++ b/exec-service/src/executor.rs
@@ -9,9 +9,6 @@ pub trait Executor {
     /// Sets the opcode costs for the given executor.
     fn set_opcode_cost(&mut self, opcode_cost: &OpcodeCost) -> Result<(), ExecutorError>;
 
-    /// Sets the log level for the given executor (default is Debug).
-    fn set_execution_log_level(&mut self, value: u64) -> Result<(), ExecutorError>;
-
     /// Creates a new VM executor instance.
     fn new_instance(
         &self,


### PR DESCRIPTION
This **PR** mostly targets the wasm logger redesign.

There are still some things that remain to be addressed:  

- [x] move set_log_level call into its own capi call