### PR TITLE
Executor cleanup

### DIFF
--- a/exec-c-api/src/capi_breakpoints.rs
+++ b/exec-c-api/src/capi_breakpoints.rs
@@ -30,10 +30,6 @@ pub unsafe extern "C" fn vm_exec_instance_set_breakpoint_value(
     }
 }
 
-fn set_breakpoint_value_u64(instance: &dyn Instance, value: u64) -> Result<(), String> {
-    instance.set_breakpoint_value(value.try_into()?)
-}
-
 /// Returns the runtime breakpoint value from the given instance.
 ///
 /// # Safety
@@ -54,4 +50,8 @@ pub unsafe extern "C" fn vm_exec_instance_get_breakpoint_value(
             0
         }
     }
+}
+
+fn set_breakpoint_value_u64(instance: &dyn Instance, value: u64) -> Result<(), String> {
+    instance.set_breakpoint_value(value.try_into()?)
 }

--- a/exec-service-wasmer/src/wasmer_executor.rs
+++ b/exec-service-wasmer/src/wasmer_executor.rs
@@ -1,5 +1,5 @@
 use crate::WasmerInstance;
-use log::trace;
+// use log::trace;
 use multiversx_vm_executor::{
     CompilationOptions, Executor, ExecutorError, Instance, OpcodeCost, ServiceError, VMHooks,
 };
@@ -66,12 +66,12 @@ impl WasmerExecutor {
 
 impl Executor for WasmerExecutor {
     fn set_vm_hooks_ptr(&mut self, vm_hooks_ptr: *mut c_void) -> Result<(), ExecutorError> {
-        trace!("Setting vmhooks ...");
+        // trace!("Setting vmhooks ...");
         self.data.borrow_mut().set_vm_hooks_ptr(vm_hooks_ptr)
     }
 
     fn set_opcode_cost(&mut self, opcode_cost: &OpcodeCost) -> Result<(), ExecutorError> {
-        trace!("Setting opcode cost...");
+        // trace!("Setting opcode cost...");
         self.data.borrow_mut().set_opcode_cost(opcode_cost)
     }
 

--- a/exec-service-wasmer/src/wasmer_executor.rs
+++ b/exec-service-wasmer/src/wasmer_executor.rs
@@ -60,12 +60,12 @@ impl WasmerExecutor {
 
 impl Executor for WasmerExecutor {
     fn set_vm_hooks_ptr(&mut self, vm_hooks_ptr: *mut c_void) -> Result<(), ExecutorError> {
-        trace!("Setting vmhooks ...");
+        // trace!("Setting vmhooks ...");
         self.data.borrow_mut().set_vm_hooks_ptr(vm_hooks_ptr)
     }
 
     fn set_opcode_cost(&mut self, opcode_cost: &OpcodeCost) -> Result<(), ExecutorError> {
-        trace!("Setting opcode cost...");
+        // trace!("Setting opcode cost...");
         self.data.borrow_mut().set_opcode_cost(opcode_cost)
     }
 

--- a/exec-service-wasmer/src/wasmer_executor.rs
+++ b/exec-service-wasmer/src/wasmer_executor.rs
@@ -1,5 +1,5 @@
 use crate::WasmerInstance;
-use log::info;
+use log::trace;
 use multiversx_vm_executor::{
     CompilationOptions, Executor, ExecutorError, Instance, OpcodeCost, ServiceError, VMHooks,
 };
@@ -8,12 +8,19 @@ use std::ffi::c_void;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
-pub struct WasmerExecutorData {
-    pub vm_hooks: Rc<Box<dyn VMHooks>>,
-    pub opcode_cost: Arc<Mutex<OpcodeCost>>,
+pub(crate) struct WasmerExecutorData {
+    vm_hooks: Rc<Box<dyn VMHooks>>,
+    opcode_cost: Arc<Mutex<OpcodeCost>>,
 }
 
 impl WasmerExecutorData {
+    fn new(vm_hooks: Box<dyn VMHooks>) -> Self {
+        Self {
+            vm_hooks: Rc::new(vm_hooks),
+            opcode_cost: Arc::new(Mutex::new(OpcodeCost::default())),
+        }
+    }
+
     fn set_vm_hooks_ptr(&mut self, vm_hooks_ptr: *mut c_void) -> Result<(), ExecutorError> {
         if let Some(vm_hooks) = Rc::get_mut(&mut self.vm_hooks) {
             vm_hooks.set_vm_hooks_ptr(vm_hooks_ptr);
@@ -29,20 +36,36 @@ impl WasmerExecutorData {
         self.opcode_cost.lock().unwrap().clone_from(opcode_cost);
         Ok(())
     }
+
+    pub(crate) fn get_vm_hooks_clone(&self) -> Rc<Box<dyn VMHooks>> {
+        self.vm_hooks.clone()
+    }
+
+    pub(crate) fn get_opcode_cost_clone(&self) -> Arc<Mutex<OpcodeCost>> {
+        self.opcode_cost.clone()
+    }
 }
 
 pub struct WasmerExecutor {
-    pub data: Rc<RefCell<WasmerExecutorData>>,
+    data: Rc<RefCell<WasmerExecutorData>>,
+}
+
+impl WasmerExecutor {
+    pub(crate) fn new(vm_hooks: Box<dyn VMHooks>) -> Self {
+        Self {
+            data: Rc::new(RefCell::new(WasmerExecutorData::new(vm_hooks))),
+        }
+    }
 }
 
 impl Executor for WasmerExecutor {
     fn set_vm_hooks_ptr(&mut self, vm_hooks_ptr: *mut c_void) -> Result<(), ExecutorError> {
-        info!("Setting vmhooks ...");
+        trace!("Setting vmhooks ...");
         self.data.borrow_mut().set_vm_hooks_ptr(vm_hooks_ptr)
     }
 
     fn set_opcode_cost(&mut self, opcode_cost: &OpcodeCost) -> Result<(), ExecutorError> {
-        info!("Setting opcode cost...");
+        trace!("Setting opcode cost...");
         self.data.borrow_mut().set_opcode_cost(opcode_cost)
     }
 

--- a/exec-service-wasmer/src/wasmer_executor.rs
+++ b/exec-service-wasmer/src/wasmer_executor.rs
@@ -33,13 +33,13 @@ impl WasmerExecutorData {
     }
 
     fn set_opcode_cost(&mut self, opcode_cost: &OpcodeCost) -> Result<(), ExecutorError> {
-        if let Some(self_opcode_cost) = Arc::get_mut(&mut self.opcode_cost) {
-            self_opcode_cost.clone_from(opcode_cost);
+        if let Some(opcode_cost_mut) = Arc::get_mut(&mut self.opcode_cost) {
+            opcode_cost_mut.clone_from(opcode_cost);
             Ok(())
         } else {
-            return Err(Box::new(ServiceError::new(
+            Err(Box::new(ServiceError::new(
                 "WasmerExecutor already set opcode cost, further configuration not allowed",
-            )));
+            )))
         }
     }
 

--- a/exec-service-wasmer/src/wasmer_executor.rs
+++ b/exec-service-wasmer/src/wasmer_executor.rs
@@ -37,11 +37,11 @@ impl WasmerExecutorData {
         Ok(())
     }
 
-    pub(crate) fn get_vm_hooks_clone(&self) -> Rc<Box<dyn VMHooks>> {
+    pub(crate) fn get_vm_hooks(&self) -> Rc<Box<dyn VMHooks>> {
         self.vm_hooks.clone()
     }
 
-    pub(crate) fn get_opcode_cost_clone(&self) -> Arc<Mutex<OpcodeCost>> {
+    pub(crate) fn get_opcode_cost(&self) -> Arc<Mutex<OpcodeCost>> {
         self.opcode_cost.clone()
     }
 }

--- a/exec-service-wasmer/src/wasmer_executor.rs
+++ b/exec-service-wasmer/src/wasmer_executor.rs
@@ -6,18 +6,18 @@ use multiversx_vm_executor::{
 use std::cell::RefCell;
 use std::ffi::c_void;
 use std::rc::Rc;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 pub(crate) struct WasmerExecutorData {
     vm_hooks: Rc<Box<dyn VMHooks>>,
-    opcode_cost: Arc<Mutex<OpcodeCost>>,
+    opcode_cost: Arc<OpcodeCost>,
 }
 
 impl WasmerExecutorData {
     fn new(vm_hooks: Box<dyn VMHooks>) -> Self {
         Self {
             vm_hooks: Rc::new(vm_hooks),
-            opcode_cost: Arc::new(Mutex::new(OpcodeCost::default())),
+            opcode_cost: Arc::new(OpcodeCost::default()),
         }
     }
 
@@ -33,15 +33,21 @@ impl WasmerExecutorData {
     }
 
     fn set_opcode_cost(&mut self, opcode_cost: &OpcodeCost) -> Result<(), ExecutorError> {
-        self.opcode_cost.lock().unwrap().clone_from(opcode_cost);
-        Ok(())
+        if let Some(self_opcode_cost) = Arc::get_mut(&mut self.opcode_cost) {
+            self_opcode_cost.clone_from(opcode_cost);
+            Ok(())
+        } else {
+            return Err(Box::new(ServiceError::new(
+                "WasmerExecutor already set opcode cost, further configuration not allowed",
+            )));
+        }
     }
 
     pub(crate) fn get_vm_hooks(&self) -> Rc<Box<dyn VMHooks>> {
         self.vm_hooks.clone()
     }
 
-    pub(crate) fn get_opcode_cost(&self) -> Arc<Mutex<OpcodeCost>> {
+    pub(crate) fn get_opcode_cost(&self) -> Arc<OpcodeCost> {
         self.opcode_cost.clone()
     }
 }
@@ -60,12 +66,12 @@ impl WasmerExecutor {
 
 impl Executor for WasmerExecutor {
     fn set_vm_hooks_ptr(&mut self, vm_hooks_ptr: *mut c_void) -> Result<(), ExecutorError> {
-        // trace!("Setting vmhooks ...");
+        trace!("Setting vmhooks ...");
         self.data.borrow_mut().set_vm_hooks_ptr(vm_hooks_ptr)
     }
 
     fn set_opcode_cost(&mut self, opcode_cost: &OpcodeCost) -> Result<(), ExecutorError> {
-        // trace!("Setting opcode cost...");
+        trace!("Setting opcode cost...");
         self.data.borrow_mut().set_opcode_cost(opcode_cost)
     }
 

--- a/exec-service-wasmer/src/wasmer_instance.rs
+++ b/exec-service-wasmer/src/wasmer_instance.rs
@@ -162,9 +162,9 @@ fn validate_memory(memory: &wasmer::Memory) -> Result<(), ExecutorError> {
         //     max_memory_pages,
         //     MAX_MEMORY_PAGES_ALLOWED
         // );
-        // return Err(Box::new(ServiceError::new(
-        //     "memory size exceeds maximum allowed",
-        // )));
+        return Err(Box::new(ServiceError::new(
+            "memory size exceeds maximum allowed",
+        )));
     }
 
     Ok(())

--- a/exec-service-wasmer/src/wasmer_instance.rs
+++ b/exec-service-wasmer/src/wasmer_instance.rs
@@ -4,7 +4,7 @@ use crate::{
     wasmer_breakpoints::*, wasmer_imports::generate_import_object, wasmer_metering::*,
     wasmer_opcode_control::OpcodeControl, wasmer_vm_hooks::VMHooksWrapper, WasmerExecutorData,
 };
-use log::trace;
+// use log::trace;
 use multiversx_vm_executor::{
     BreakpointValue, CompilationOptions, ExecutorError, Instance, ServiceError,
 };
@@ -38,17 +38,17 @@ impl WasmerInstance {
         // Create the store
         let store = Store::new(&Universal::new(compiler).engine());
 
-        trace!("Compiling module ...");
+        // trace!("Compiling module ...");
         let module = Module::new(&store, wasm_bytes)?;
 
         // Create an empty import object.
-        trace!("Generating imports ...");
+        // trace!("Generating imports ...");
         let vm_hooks_wrapper = VMHooksWrapper {
             vm_hooks: executor_data.borrow().get_vm_hooks(),
         };
         let import_object = generate_import_object(&store, &vm_hooks_wrapper);
 
-        trace!("Instantiating WasmerInstance ...");
+        // trace!("Instantiating WasmerInstance ...");
         let wasmer_instance = wasmer::Instance::new(&module, &import_object)?;
         set_points_limit(&wasmer_instance, compilation_options.gas_limit)?;
 
@@ -61,7 +61,7 @@ impl WasmerInstance {
         // Checks that the memory size is not greater than the maximum allowed
         validate_memory(memory)?;
 
-        trace!("WasmerMemory size: {:#?}", memory.size());
+        // trace!("WasmerMemory size: {:#?}", memory.size());
         let memory_name = memories[0].0.clone();
 
         Ok(Box::new(WasmerInstance {
@@ -84,20 +84,20 @@ impl WasmerInstance {
         // Create the store
         let store = Store::new(&Universal::new(compiler).engine());
 
-        trace!("Deserializing module ...");
+        // trace!("Deserializing module ...");
         let module;
         unsafe {
             module = Module::deserialize(&store, cache_bytes)?;
         };
 
         // Create an empty import object.
-        trace!("Generating imports ...");
+        // trace!("Generating imports ...");
         let vm_hooks_wrapper = VMHooksWrapper {
             vm_hooks: executor_data.borrow().get_vm_hooks(),
         };
         let import_object = generate_import_object(&store, &vm_hooks_wrapper);
 
-        trace!("Instantiating WasmerInstance ...");
+        // trace!("Instantiating WasmerInstance ...");
         let wasmer_instance = wasmer::Instance::new(&module, &import_object)?;
         set_points_limit(&wasmer_instance, compilation_options.gas_limit)?;
 
@@ -110,7 +110,7 @@ impl WasmerInstance {
         // Checks that the memory size is not greater than the maximum allowed
         validate_memory(memory)?;
 
-        trace!("WasmerMemory size: {:#?}", memory.size());
+        // trace!("WasmerMemory size: {:#?}", memory.size());
         let memory_name = memories[0].0.clone();
 
         Ok(Box::new(WasmerInstance {
@@ -157,14 +157,14 @@ fn validate_memory(memory: &wasmer::Memory) -> Result<(), ExecutorError> {
     let max_memory_pages = memory_type.maximum.unwrap_or(memory_type.minimum);
 
     if max_memory_pages > MAX_MEMORY_PAGES_ALLOWED {
-        trace!(
-            "Memory size exceeds maximum allowed: {:#?} > {:#?}",
-            max_memory_pages,
-            MAX_MEMORY_PAGES_ALLOWED
-        );
-        return Err(Box::new(ServiceError::new(
-            "memory size exceeds maximum allowed",
-        )));
+        // trace!(
+        //     "Memory size exceeds maximum allowed: {:#?} > {:#?}",
+        //     max_memory_pages,
+        //     MAX_MEMORY_PAGES_ALLOWED
+        // );
+        // return Err(Box::new(ServiceError::new(
+        //     "memory size exceeds maximum allowed",
+        // )));
     }
 
     Ok(())
@@ -199,26 +199,26 @@ fn push_middlewares(
         metering_middleware.clone(),
     ]));
 
-    trace!("Adding protected_globals middleware ...");
+    // trace!("Adding protected_globals middleware ...");
     compiler.push_middleware(protected_globals_middleware);
-    trace!("Adding metering middleware ...");
+    // trace!("Adding metering middleware ...");
     compiler.push_middleware(metering_middleware);
-    trace!("Adding opcode_control middleware ...");
+    // trace!("Adding opcode_control middleware ...");
     compiler.push_middleware(opcode_control_middleware);
-    trace!("Adding breakpoints middleware ...");
+    // trace!("Adding breakpoints middleware ...");
     compiler.push_middleware(breakpoints_middleware);
 
     if compilation_options.opcode_trace {
         // Create opcode_tracer middleware
         let opcode_tracer_middleware = Arc::new(OpcodeTracer::new());
-        trace!("Adding opcode_tracer middleware ...");
+        // trace!("Adding opcode_tracer middleware ...");
         compiler.push_middleware(opcode_tracer_middleware);
     }
 }
 
 impl Instance for WasmerInstance {
     fn call(&self, func_name: &str) -> Result<(), String> {
-        trace!("Rust instance call: {func_name}");
+        // trace!("Rust instance call: {func_name}");
 
         let func = self
             .wasmer_instance
@@ -228,11 +228,11 @@ impl Instance for WasmerInstance {
 
         match func.call(&[]) {
             Ok(_) => {
-                trace!("Call succeeded: {func_name}");
+                // trace!("Call succeeded: {func_name}");
                 Ok(())
             }
             Err(err) => {
-                trace!("Call failed: {func_name} - {err}");
+                // trace!("Call failed: {func_name} - {err}");
                 Err(err.to_string())
             }
         }

--- a/exec-service-wasmer/src/wasmer_instance.rs
+++ b/exec-service-wasmer/src/wasmer_instance.rs
@@ -4,7 +4,7 @@ use crate::{
     wasmer_breakpoints::*, wasmer_imports::generate_import_object, wasmer_metering::*,
     wasmer_opcode_control::OpcodeControl, wasmer_vm_hooks::VMHooksWrapper, WasmerExecutorData,
 };
-// use log::trace;
+use log::trace;
 use multiversx_vm_executor::{
     BreakpointValue, CompilationOptions, ExecutorError, Instance, ServiceError,
 };
@@ -38,17 +38,17 @@ impl WasmerInstance {
         // Create the store
         let store = Store::new(&Universal::new(compiler).engine());
 
-        // trace!("Compiling module ...");
+        trace!("Compiling module ...");
         let module = Module::new(&store, wasm_bytes)?;
 
         // Create an empty import object.
-        // trace!("Generating imports ...");
+        trace!("Generating imports ...");
         let vm_hooks_wrapper = VMHooksWrapper {
             vm_hooks: executor_data.borrow().get_vm_hooks(),
         };
         let import_object = generate_import_object(&store, &vm_hooks_wrapper);
 
-        // trace!("Instantiating WasmerInstance ...");
+        trace!("Instantiating WasmerInstance ...");
         let wasmer_instance = wasmer::Instance::new(&module, &import_object)?;
         set_points_limit(&wasmer_instance, compilation_options.gas_limit)?;
 
@@ -61,7 +61,7 @@ impl WasmerInstance {
         // Checks that the memory size is not greater than the maximum allowed
         validate_memory(memory)?;
 
-        // trace!("WasmerMemory size: {:#?}", memory.size());
+        trace!("WasmerMemory size: {:#?}", memory.size());
         let memory_name = memories[0].0.clone();
 
         Ok(Box::new(WasmerInstance {
@@ -84,20 +84,20 @@ impl WasmerInstance {
         // Create the store
         let store = Store::new(&Universal::new(compiler).engine());
 
-        // trace!("Deserializing module ...");
+        trace!("Deserializing module ...");
         let module;
         unsafe {
             module = Module::deserialize(&store, cache_bytes)?;
         };
 
         // Create an empty import object.
-        // trace!("Generating imports ...");
+        trace!("Generating imports ...");
         let vm_hooks_wrapper = VMHooksWrapper {
             vm_hooks: executor_data.borrow().get_vm_hooks(),
         };
         let import_object = generate_import_object(&store, &vm_hooks_wrapper);
 
-        // trace!("Instantiating WasmerInstance ...");
+        trace!("Instantiating WasmerInstance ...");
         let wasmer_instance = wasmer::Instance::new(&module, &import_object)?;
         set_points_limit(&wasmer_instance, compilation_options.gas_limit)?;
 
@@ -110,7 +110,7 @@ impl WasmerInstance {
         // Checks that the memory size is not greater than the maximum allowed
         validate_memory(memory)?;
 
-        // trace!("WasmerMemory size: {:#?}", memory.size());
+        trace!("WasmerMemory size: {:#?}", memory.size());
         let memory_name = memories[0].0.clone();
 
         Ok(Box::new(WasmerInstance {
@@ -157,11 +157,11 @@ fn validate_memory(memory: &wasmer::Memory) -> Result<(), ExecutorError> {
     let max_memory_pages = memory_type.maximum.unwrap_or(memory_type.minimum);
 
     if max_memory_pages > MAX_MEMORY_PAGES_ALLOWED {
-        // trace!(
-        //     "Memory size exceeds maximum allowed: {:#?} > {:#?}",
-        //     max_memory_pages,
-        //     MAX_MEMORY_PAGES_ALLOWED
-        // );
+        trace!(
+            "Memory size exceeds maximum allowed: {:#?} > {:#?}",
+            max_memory_pages,
+            MAX_MEMORY_PAGES_ALLOWED
+        );
         return Err(Box::new(ServiceError::new(
             "memory size exceeds maximum allowed",
         )));
@@ -199,26 +199,26 @@ fn push_middlewares(
         metering_middleware.clone(),
     ]));
 
-    // trace!("Adding protected_globals middleware ...");
+    trace!("Adding protected_globals middleware ...");
     compiler.push_middleware(protected_globals_middleware);
-    // trace!("Adding metering middleware ...");
+    trace!("Adding metering middleware ...");
     compiler.push_middleware(metering_middleware);
-    // trace!("Adding opcode_control middleware ...");
+    trace!("Adding opcode_control middleware ...");
     compiler.push_middleware(opcode_control_middleware);
-    // trace!("Adding breakpoints middleware ...");
+    trace!("Adding breakpoints middleware ...");
     compiler.push_middleware(breakpoints_middleware);
 
     if compilation_options.opcode_trace {
         // Create opcode_tracer middleware
         let opcode_tracer_middleware = Arc::new(OpcodeTracer::new());
-        // trace!("Adding opcode_tracer middleware ...");
+        trace!("Adding opcode_tracer middleware ...");
         compiler.push_middleware(opcode_tracer_middleware);
     }
 }
 
 impl Instance for WasmerInstance {
     fn call(&self, func_name: &str) -> Result<(), String> {
-        // trace!("Rust instance call: {func_name}");
+        trace!("Rust instance call: {func_name}");
 
         let func = self
             .wasmer_instance
@@ -228,11 +228,11 @@ impl Instance for WasmerInstance {
 
         match func.call(&[]) {
             Ok(_) => {
-                // trace!("Call succeeded: {func_name}");
+                trace!("Call succeeded: {func_name}");
                 Ok(())
             }
             Err(err) => {
-                // trace!("Call failed: {func_name} - {err}");
+                trace!("Call failed: {func_name} - {err}");
                 Err(err.to_string())
             }
         }

--- a/exec-service-wasmer/src/wasmer_instance.rs
+++ b/exec-service-wasmer/src/wasmer_instance.rs
@@ -9,6 +9,7 @@ use multiversx_vm_executor::{
     BreakpointValue, CompilationOptions, ExecutorError, Instance, ServiceError,
 };
 use multiversx_vm_executor::{MemLength, MemPtr};
+
 use std::cell::RefCell;
 use std::{rc::Rc, sync::Arc};
 use wasmer::Universal;
@@ -37,17 +38,17 @@ impl WasmerInstance {
         // Create the store
         let store = Store::new(&Universal::new(compiler).engine());
 
-        // trace!("Compiling module ...");
+        trace!("Compiling module ...");
         let module = Module::new(&store, wasm_bytes)?;
 
         // Create an empty import object.
-        // trace!("Generating imports ...");
+        trace!("Generating imports ...");
         let vm_hooks_wrapper = VMHooksWrapper {
             vm_hooks: executor_data.borrow().get_vm_hooks(),
         };
         let import_object = generate_import_object(&store, &vm_hooks_wrapper);
 
-        // trace!("Instantiating WasmerInstance ...");
+        trace!("Instantiating WasmerInstance ...");
         let wasmer_instance = wasmer::Instance::new(&module, &import_object)?;
         set_points_limit(&wasmer_instance, compilation_options.gas_limit)?;
 
@@ -60,7 +61,7 @@ impl WasmerInstance {
         // Checks that the memory size is not greater than the maximum allowed
         validate_memory(memory)?;
 
-        // trace!("WasmerMemory size: {:#?}", memory.size());
+        trace!("WasmerMemory size: {:#?}", memory.size());
         let memory_name = memories[0].0.clone();
 
         Ok(Box::new(WasmerInstance {
@@ -83,20 +84,20 @@ impl WasmerInstance {
         // Create the store
         let store = Store::new(&Universal::new(compiler).engine());
 
-        // trace!("Deserializing module ...");
+        trace!("Deserializing module ...");
         let module;
         unsafe {
             module = Module::deserialize(&store, cache_bytes)?;
         };
 
         // Create an empty import object.
-        // trace!("Generating imports ...");
+        trace!("Generating imports ...");
         let vm_hooks_wrapper = VMHooksWrapper {
             vm_hooks: executor_data.borrow().get_vm_hooks(),
         };
         let import_object = generate_import_object(&store, &vm_hooks_wrapper);
 
-        // trace!("Instantiating WasmerInstance ...");
+        trace!("Instantiating WasmerInstance ...");
         let wasmer_instance = wasmer::Instance::new(&module, &import_object)?;
         set_points_limit(&wasmer_instance, compilation_options.gas_limit)?;
 
@@ -109,7 +110,7 @@ impl WasmerInstance {
         // Checks that the memory size is not greater than the maximum allowed
         validate_memory(memory)?;
 
-        // trace!("WasmerMemory size: {:#?}", memory.size());
+        trace!("WasmerMemory size: {:#?}", memory.size());
         let memory_name = memories[0].0.clone();
 
         Ok(Box::new(WasmerInstance {
@@ -156,11 +157,11 @@ fn validate_memory(memory: &wasmer::Memory) -> Result<(), ExecutorError> {
     let max_memory_pages = memory_type.maximum.unwrap_or(memory_type.minimum);
 
     if max_memory_pages > MAX_MEMORY_PAGES_ALLOWED {
-        // trace!(
-        //     "Memory size exceeds maximum allowed: {:#?} > {:#?}",
-        //     max_memory_pages,
-        //     MAX_MEMORY_PAGES_ALLOWED
-        // );
+        trace!(
+            "Memory size exceeds maximum allowed: {:#?} > {:#?}",
+            max_memory_pages,
+            MAX_MEMORY_PAGES_ALLOWED
+        );
         return Err(Box::new(ServiceError::new(
             "memory size exceeds maximum allowed",
         )));
@@ -198,26 +199,26 @@ fn push_middlewares(
         metering_middleware.clone(),
     ]));
 
-    // trace!("Adding protected_globals middleware ...");
+    trace!("Adding protected_globals middleware ...");
     compiler.push_middleware(protected_globals_middleware);
-    // trace!("Adding metering middleware ...");
+    trace!("Adding metering middleware ...");
     compiler.push_middleware(metering_middleware);
-    // trace!("Adding opcode_control middleware ...");
+    trace!("Adding opcode_control middleware ...");
     compiler.push_middleware(opcode_control_middleware);
-    // trace!("Adding breakpoints middleware ...");
+    trace!("Adding breakpoints middleware ...");
     compiler.push_middleware(breakpoints_middleware);
 
     if compilation_options.opcode_trace {
         // Create opcode_tracer middleware
         let opcode_tracer_middleware = Arc::new(OpcodeTracer::new());
-        // trace!("Adding opcode_tracer middleware ...");
+        trace!("Adding opcode_tracer middleware ...");
         compiler.push_middleware(opcode_tracer_middleware);
     }
 }
 
 impl Instance for WasmerInstance {
     fn call(&self, func_name: &str) -> Result<(), String> {
-        // trace!("Rust instance call: {func_name}");
+        trace!("Rust instance call: {func_name}");
 
         let func = self
             .wasmer_instance
@@ -227,11 +228,11 @@ impl Instance for WasmerInstance {
 
         match func.call(&[]) {
             Ok(_) => {
-                // trace!("Call succeeded: {func_name}");
+                trace!("Call succeeded: {func_name}");
                 Ok(())
             }
             Err(err) => {
-                // trace!("Call failed: {func_name} - {err}");
+                trace!("Call failed: {func_name} - {err}");
                 Err(err.to_string())
             }
         }

--- a/exec-service-wasmer/src/wasmer_instance.rs
+++ b/exec-service-wasmer/src/wasmer_instance.rs
@@ -43,7 +43,7 @@ impl WasmerInstance {
         // Create an empty import object.
         trace!("Generating imports ...");
         let vm_hooks_wrapper = VMHooksWrapper {
-            vm_hooks: executor_data.borrow().get_vm_hooks_clone(),
+            vm_hooks: executor_data.borrow().get_vm_hooks(),
         };
         let import_object = generate_import_object(&store, &vm_hooks_wrapper);
 
@@ -92,7 +92,7 @@ impl WasmerInstance {
         // Create an empty import object.
         trace!("Generating imports ...");
         let vm_hooks_wrapper = VMHooksWrapper {
-            vm_hooks: executor_data.borrow().get_vm_hooks_clone(),
+            vm_hooks: executor_data.borrow().get_vm_hooks(),
         };
         let import_object = generate_import_object(&store, &vm_hooks_wrapper);
 
@@ -188,7 +188,7 @@ fn push_middlewares(
     let metering_middleware = Arc::new(Metering::new(
         compilation_options.gas_limit,
         compilation_options.unmetered_locals,
-        executor_data.borrow().get_opcode_cost_clone(),
+        executor_data.borrow().get_opcode_cost(),
         breakpoints_middleware.clone(),
     ));
 

--- a/exec-service-wasmer/src/wasmer_instance.rs
+++ b/exec-service-wasmer/src/wasmer_instance.rs
@@ -37,17 +37,17 @@ impl WasmerInstance {
         // Create the store
         let store = Store::new(&Universal::new(compiler).engine());
 
-        trace!("Compiling module ...");
+        // trace!("Compiling module ...");
         let module = Module::new(&store, wasm_bytes)?;
 
         // Create an empty import object.
-        trace!("Generating imports ...");
+        // trace!("Generating imports ...");
         let vm_hooks_wrapper = VMHooksWrapper {
             vm_hooks: executor_data.borrow().get_vm_hooks(),
         };
         let import_object = generate_import_object(&store, &vm_hooks_wrapper);
 
-        trace!("Instantiating WasmerInstance ...");
+        // trace!("Instantiating WasmerInstance ...");
         let wasmer_instance = wasmer::Instance::new(&module, &import_object)?;
         set_points_limit(&wasmer_instance, compilation_options.gas_limit)?;
 
@@ -60,7 +60,7 @@ impl WasmerInstance {
         // Checks that the memory size is not greater than the maximum allowed
         validate_memory(memory)?;
 
-        trace!("WasmerMemory size: {:#?}", memory.size());
+        // trace!("WasmerMemory size: {:#?}", memory.size());
         let memory_name = memories[0].0.clone();
 
         Ok(Box::new(WasmerInstance {
@@ -83,20 +83,20 @@ impl WasmerInstance {
         // Create the store
         let store = Store::new(&Universal::new(compiler).engine());
 
-        trace!("Deserializing module ...");
+        // trace!("Deserializing module ...");
         let module;
         unsafe {
             module = Module::deserialize(&store, cache_bytes)?;
         };
 
         // Create an empty import object.
-        trace!("Generating imports ...");
+        // trace!("Generating imports ...");
         let vm_hooks_wrapper = VMHooksWrapper {
             vm_hooks: executor_data.borrow().get_vm_hooks(),
         };
         let import_object = generate_import_object(&store, &vm_hooks_wrapper);
 
-        trace!("Instantiating WasmerInstance ...");
+        // trace!("Instantiating WasmerInstance ...");
         let wasmer_instance = wasmer::Instance::new(&module, &import_object)?;
         set_points_limit(&wasmer_instance, compilation_options.gas_limit)?;
 
@@ -109,7 +109,7 @@ impl WasmerInstance {
         // Checks that the memory size is not greater than the maximum allowed
         validate_memory(memory)?;
 
-        trace!("WasmerMemory size: {:#?}", memory.size());
+        // trace!("WasmerMemory size: {:#?}", memory.size());
         let memory_name = memories[0].0.clone();
 
         Ok(Box::new(WasmerInstance {
@@ -156,11 +156,11 @@ fn validate_memory(memory: &wasmer::Memory) -> Result<(), ExecutorError> {
     let max_memory_pages = memory_type.maximum.unwrap_or(memory_type.minimum);
 
     if max_memory_pages > MAX_MEMORY_PAGES_ALLOWED {
-        trace!(
-            "Memory size exceeds maximum allowed: {:#?} > {:#?}",
-            max_memory_pages,
-            MAX_MEMORY_PAGES_ALLOWED
-        );
+        // trace!(
+        //     "Memory size exceeds maximum allowed: {:#?} > {:#?}",
+        //     max_memory_pages,
+        //     MAX_MEMORY_PAGES_ALLOWED
+        // );
         return Err(Box::new(ServiceError::new(
             "memory size exceeds maximum allowed",
         )));
@@ -198,26 +198,26 @@ fn push_middlewares(
         metering_middleware.clone(),
     ]));
 
-    trace!("Adding protected_globals middleware ...");
+    // trace!("Adding protected_globals middleware ...");
     compiler.push_middleware(protected_globals_middleware);
-    trace!("Adding metering middleware ...");
+    // trace!("Adding metering middleware ...");
     compiler.push_middleware(metering_middleware);
-    trace!("Adding opcode_control middleware ...");
+    // trace!("Adding opcode_control middleware ...");
     compiler.push_middleware(opcode_control_middleware);
-    trace!("Adding breakpoints middleware ...");
+    // trace!("Adding breakpoints middleware ...");
     compiler.push_middleware(breakpoints_middleware);
 
     if compilation_options.opcode_trace {
         // Create opcode_tracer middleware
         let opcode_tracer_middleware = Arc::new(OpcodeTracer::new());
-        trace!("Adding opcode_tracer middleware ...");
+        // trace!("Adding opcode_tracer middleware ...");
         compiler.push_middleware(opcode_tracer_middleware);
     }
 }
 
 impl Instance for WasmerInstance {
     fn call(&self, func_name: &str) -> Result<(), String> {
-        trace!("Rust instance call: {func_name}");
+        // trace!("Rust instance call: {func_name}");
 
         let func = self
             .wasmer_instance
@@ -227,11 +227,11 @@ impl Instance for WasmerInstance {
 
         match func.call(&[]) {
             Ok(_) => {
-                trace!("Call succeeded: {func_name}");
+                // trace!("Call succeeded: {func_name}");
                 Ok(())
             }
             Err(err) => {
-                trace!("Call failed: {func_name} - {err}");
+                // trace!("Call failed: {func_name} - {err}");
                 Err(err.to_string())
             }
         }

--- a/exec-service-wasmer/src/wasmer_logger.rs
+++ b/exec-service-wasmer/src/wasmer_logger.rs
@@ -1,6 +1,6 @@
 use chrono::Local;
 
-use log::{info, Level, LevelFilter, Metadata, Record};
+use log::{trace, Level, LevelFilter, Metadata, Record};
 
 struct WasmerLogger;
 
@@ -38,7 +38,7 @@ pub fn init(log_level: LevelFilter) {
         log::set_boxed_logger(Box::new(WasmerLogger))
             .map(|()| {
                 log::set_max_level(log_level);
-                info!("Initializing WasmerLogger with {log_level} ...");
+                trace!("Initializing WasmerLogger with {log_level} ...");
             })
             .unwrap();
     });
@@ -51,7 +51,7 @@ pub fn set_log_level(log_level: LevelFilter) {
     }
 
     log::set_max_level(log_level);
-    info!("Setting log level to {log_level} ...");
+    trace!("Setting log level to {log_level} ...");
 }
 
 pub fn u64_to_log_level(value: u64) -> Result<LevelFilter, &'static str> {

--- a/exec-service-wasmer/src/wasmer_logger.rs
+++ b/exec-service-wasmer/src/wasmer_logger.rs
@@ -1,5 +1,4 @@
 use chrono::Local;
-
 use log::{trace, Level, LevelFilter, Metadata, Record};
 
 struct WasmerLogger;
@@ -38,7 +37,7 @@ pub fn init(log_level: LevelFilter) {
         log::set_boxed_logger(Box::new(WasmerLogger))
             .map(|()| {
                 log::set_max_level(log_level);
-                // trace!("Initializing WasmerLogger with {log_level} ...");
+                trace!("Initializing WasmerLogger with {log_level} ...");
             })
             .unwrap();
     });
@@ -51,7 +50,7 @@ pub fn set_log_level(log_level: LevelFilter) {
     }
 
     log::set_max_level(log_level);
-    // trace!("Setting log level to {log_level} ...");
+    trace!("Setting log level to {log_level} ...");
 }
 
 pub fn u64_to_log_level(value: u64) -> Result<LevelFilter, &'static str> {

--- a/exec-service-wasmer/src/wasmer_logger.rs
+++ b/exec-service-wasmer/src/wasmer_logger.rs
@@ -38,7 +38,7 @@ pub fn init(log_level: LevelFilter) {
         log::set_boxed_logger(Box::new(WasmerLogger))
             .map(|()| {
                 log::set_max_level(log_level);
-                trace!("Initializing WasmerLogger with {log_level} ...");
+                // trace!("Initializing WasmerLogger with {log_level} ...");
             })
             .unwrap();
     });
@@ -51,7 +51,7 @@ pub fn set_log_level(log_level: LevelFilter) {
     }
 
     log::set_max_level(log_level);
-    trace!("Setting log level to {log_level} ...");
+    // trace!("Setting log level to {log_level} ...");
 }
 
 pub fn u64_to_log_level(value: u64) -> Result<LevelFilter, &'static str> {

--- a/exec-service-wasmer/src/wasmer_logger.rs
+++ b/exec-service-wasmer/src/wasmer_logger.rs
@@ -1,5 +1,5 @@
 use chrono::Local;
-// use log::trace;
+use log::trace;
 use log::{Level, LevelFilter, Metadata, Record};
 
 struct WasmerLogger;
@@ -38,7 +38,7 @@ pub fn init(log_level: LevelFilter) {
         log::set_boxed_logger(Box::new(WasmerLogger))
             .map(|()| {
                 log::set_max_level(log_level);
-                // trace!("Initializing WasmerLogger with {log_level} ...");
+                trace!("Initializing WasmerLogger with {log_level} ...");
             })
             .unwrap();
     });
@@ -51,7 +51,7 @@ pub fn set_log_level(log_level: LevelFilter) {
     }
 
     log::set_max_level(log_level);
-    // trace!("Setting log level to {log_level} ...");
+    trace!("Setting log level to {log_level} ...");
 }
 
 pub fn u64_to_log_level(value: u64) -> Result<LevelFilter, &'static str> {

--- a/exec-service-wasmer/src/wasmer_logger.rs
+++ b/exec-service-wasmer/src/wasmer_logger.rs
@@ -1,5 +1,6 @@
 use chrono::Local;
-use log::{trace, Level, LevelFilter, Metadata, Record};
+// use log::trace;
+use log::{Level, LevelFilter, Metadata, Record};
 
 struct WasmerLogger;
 
@@ -37,7 +38,7 @@ pub fn init(log_level: LevelFilter) {
         log::set_boxed_logger(Box::new(WasmerLogger))
             .map(|()| {
                 log::set_max_level(log_level);
-                trace!("Initializing WasmerLogger with {log_level} ...");
+                // trace!("Initializing WasmerLogger with {log_level} ...");
             })
             .unwrap();
     });
@@ -50,7 +51,7 @@ pub fn set_log_level(log_level: LevelFilter) {
     }
 
     log::set_max_level(log_level);
-    trace!("Setting log level to {log_level} ...");
+    // trace!("Setting log level to {log_level} ...");
 }
 
 pub fn u64_to_log_level(value: u64) -> Result<LevelFilter, &'static str> {

--- a/exec-service-wasmer/src/wasmer_metering.rs
+++ b/exec-service-wasmer/src/wasmer_metering.rs
@@ -26,7 +26,7 @@ struct MeteringGlobalIndexes {
 pub(crate) struct Metering {
     points_limit: u64,
     unmetered_locals: usize,
-    opcode_cost: Arc<OpcodeCost>,
+    opcode_cost: Arc<Mutex<OpcodeCost>>,
     breakpoints_middleware: Arc<Breakpoints>,
     global_indexes: Mutex<Option<MeteringGlobalIndexes>>,
 }
@@ -35,7 +35,7 @@ impl Metering {
     pub(crate) fn new(
         points_limit: u64,
         unmetered_locals: usize,
-        opcode_cost: Arc<OpcodeCost>,
+        opcode_cost: Arc<Mutex<OpcodeCost>>,
         breakpoints_middleware: Arc<Breakpoints>,
     ) -> Self {
         Self {
@@ -119,7 +119,7 @@ impl MiddlewareWithProtectedGlobals for Metering {
 struct FunctionMetering {
     accumulated_cost: u64,
     unmetered_locals: usize,
-    opcode_cost: Arc<OpcodeCost>,
+    opcode_cost: Arc<Mutex<OpcodeCost>>,
     breakpoints_middleware: Arc<Breakpoints>,
     global_indexes: MeteringGlobalIndexes,
 }
@@ -164,7 +164,7 @@ impl FunctionMiddleware for FunctionMetering {
         // Get the cost of the current operator, and add it to the accumulator.
         // This needs to be done before the metering logic, to prevent operators like `Call` from escaping metering in some
         // corner cases.
-        let option = get_opcode_cost(&operator, &self.opcode_cost);
+        let option = get_opcode_cost(&operator, &self.opcode_cost.lock().unwrap());
         match option {
             Some(cost) => self.accumulated_cost += cost as u64,
             None => {
@@ -207,7 +207,7 @@ impl FunctionMiddleware for FunctionMetering {
         let unmetered_locals = self.unmetered_locals as u32;
         if count > unmetered_locals {
             let metered_locals = count - unmetered_locals;
-            let local_cost = get_local_cost(&self.opcode_cost);
+            let local_cost = get_local_cost(&self.opcode_cost.lock().unwrap());
             let metered_locals_cost = metered_locals * local_cost;
             self.accumulated_cost += metered_locals_cost as u64;
         }

--- a/exec-service-wasmer/src/wasmer_service.rs
+++ b/exec-service-wasmer/src/wasmer_service.rs
@@ -41,7 +41,7 @@ impl ExecutorService for BasicExecutorService {
         &self,
         vm_hooks_builder: Box<dyn VMHooks>,
     ) -> Result<Box<dyn Executor>, ExecutorError> {
-        trace!("Initializing WasmerExecutor ...");
+        // trace!("Initializing WasmerExecutor ...");
         Ok(Box::new(WasmerExecutor::new(vm_hooks_builder)))
     }
 }

--- a/exec-service-wasmer/src/wasmer_service.rs
+++ b/exec-service-wasmer/src/wasmer_service.rs
@@ -1,5 +1,4 @@
-use log::trace;
-use log::LevelFilter;
+use log::{trace, LevelFilter};
 use multiversx_vm_executor::{
     Executor, ExecutorError, ExecutorLastError, ExecutorService, VMHooks,
 };
@@ -22,7 +21,7 @@ impl BasicExecutorService {
 
     fn init() {
         // Initialize the logger only once
-        // WasmerLogger::init(LevelFilter::Off);
+        WasmerLogger::init(LevelFilter::Off);
     }
 }
 
@@ -41,7 +40,7 @@ impl ExecutorService for BasicExecutorService {
         &self,
         vm_hooks_builder: Box<dyn VMHooks>,
     ) -> Result<Box<dyn Executor>, ExecutorError> {
-        // trace!("Initializing WasmerExecutor ...");
+        trace!("Initializing WasmerExecutor ...");
         Ok(Box::new(WasmerExecutor::new(vm_hooks_builder)))
     }
 }

--- a/exec-service-wasmer/src/wasmer_service.rs
+++ b/exec-service-wasmer/src/wasmer_service.rs
@@ -22,7 +22,7 @@ impl BasicExecutorService {
 
     fn init() {
         // Initialize the logger only once
-        WasmerLogger::init(LevelFilter::Off);
+        // WasmerLogger::init(LevelFilter::Off);
     }
 }
 

--- a/exec-service-wasmer/src/wasmer_service.rs
+++ b/exec-service-wasmer/src/wasmer_service.rs
@@ -1,9 +1,9 @@
-use log::{trace, LevelFilter};
+// use log::{trace, LevelFilter};
 use multiversx_vm_executor::{
     Executor, ExecutorError, ExecutorLastError, ExecutorService, VMHooks,
 };
 
-use crate::wasmer_logger as WasmerLogger;
+// use crate::wasmer_logger as WasmerLogger;
 use crate::WasmerExecutor;
 
 #[derive(Default)]
@@ -21,7 +21,7 @@ impl BasicExecutorService {
 
     fn init() {
         // Initialize the logger only once
-        WasmerLogger::init(LevelFilter::Off);
+        // WasmerLogger::init(LevelFilter::Off);
     }
 }
 
@@ -40,7 +40,7 @@ impl ExecutorService for BasicExecutorService {
         &self,
         vm_hooks_builder: Box<dyn VMHooks>,
     ) -> Result<Box<dyn Executor>, ExecutorError> {
-        trace!("Initializing WasmerExecutor ...");
+        // trace!("Initializing WasmerExecutor ...");
         Ok(Box::new(WasmerExecutor::new(vm_hooks_builder)))
     }
 }

--- a/exec-service-wasmer/src/wasmer_service.rs
+++ b/exec-service-wasmer/src/wasmer_service.rs
@@ -1,8 +1,9 @@
-// use log::{trace, LevelFilter};
+use log::trace;
 use multiversx_vm_executor::{
     Executor, ExecutorError, ExecutorLastError, ExecutorService, VMHooks,
 };
 
+// use log::LevelFilter;
 // use crate::wasmer_logger as WasmerLogger;
 use crate::WasmerExecutor;
 
@@ -20,7 +21,7 @@ impl BasicExecutorService {
     }
 
     fn init() {
-        // Initialize the logger only once
+        // Initialize the logger only once (disable until we sync with node)
         // WasmerLogger::init(LevelFilter::Off);
     }
 }
@@ -40,7 +41,7 @@ impl ExecutorService for BasicExecutorService {
         &self,
         vm_hooks_builder: Box<dyn VMHooks>,
     ) -> Result<Box<dyn Executor>, ExecutorError> {
-        // trace!("Initializing WasmerExecutor ...");
+        trace!("Initializing WasmerExecutor ...");
         Ok(Box::new(WasmerExecutor::new(vm_hooks_builder)))
     }
 }

--- a/exec-service-wasmer/src/wasmer_service.rs
+++ b/exec-service-wasmer/src/wasmer_service.rs
@@ -1,8 +1,4 @@
-use std::cell::RefCell;
-use std::rc::Rc;
-use std::sync::Arc;
-
-use log::info;
+use log::trace;
 use log::LevelFilter;
 use multiversx_vm_executor::{
     Executor, ExecutorError, ExecutorLastError, ExecutorService, VMHooks,
@@ -10,7 +6,6 @@ use multiversx_vm_executor::{
 
 use crate::wasmer_logger as WasmerLogger;
 use crate::WasmerExecutor;
-use crate::WasmerExecutorData;
 
 #[derive(Default)]
 pub struct BasicExecutorService {
@@ -27,7 +22,7 @@ impl BasicExecutorService {
 
     fn init() {
         // Initialize the logger only once
-        WasmerLogger::init(LevelFilter::Trace);
+        WasmerLogger::init(LevelFilter::Off);
     }
 }
 
@@ -46,14 +41,7 @@ impl ExecutorService for BasicExecutorService {
         &self,
         vm_hooks_builder: Box<dyn VMHooks>,
     ) -> Result<Box<dyn Executor>, ExecutorError> {
-        info!("Initializing WasmerExecutor ...");
-
-        let data = WasmerExecutorData {
-            vm_hooks: Rc::new(vm_hooks_builder),
-            opcode_cost: Arc::new(Default::default()),
-        };
-        Ok(Box::new(WasmerExecutor {
-            data: Rc::new(RefCell::new(data)),
-        }))
+        trace!("Initializing WasmerExecutor ...");
+        Ok(Box::new(WasmerExecutor::new(vm_hooks_builder)))
     }
 }


### PR DESCRIPTION
- add constructors for `WasmerExecutor` and `WasmerExecutorData`
- change all log prints to `trace!`
- set default `WasmerLogger` level `Off` (disabled until we sync with node)
- proper encapsulation
- refactors