### PR TITLE
add managedGetAllTransfersCallValue hoook

### DIFF
--- a/c-api/libvmexeccapi.h
+++ b/c-api/libvmexeccapi.h
@@ -136,6 +136,7 @@ typedef struct {
   void (*managed_get_prev_block_random_seed_func_ptr)(void *context, int32_t result_handle);
   void (*managed_get_return_data_func_ptr)(void *context, int32_t result_id, int32_t result_handle);
   void (*managed_get_multi_esdt_call_value_func_ptr)(void *context, int32_t multi_call_value_handle);
+  void (*managed_get_all_transfers_call_value_func_ptr)(void *context, int32_t value_handle);
   void (*managed_get_back_transfers_func_ptr)(void *context, int32_t esdt_transfers_value_handle, int32_t egld_value_handle);
   void (*managed_get_esdt_balance_func_ptr)(void *context, int32_t address_handle, int32_t token_id_handle, int64_t nonce, int32_t value_handle);
   void (*managed_get_esdt_token_data_func_ptr)(void *context, int32_t address_handle, int32_t token_id_handle, int64_t nonce, int32_t value_handle, int32_t properties_handle, int32_t hash_handle, int32_t name_handle, int32_t attributes_handle, int32_t creator_handle, int32_t royalties_handle, int32_t uris_handle);

--- a/c-api/src/capi_vm_hook_pointers.rs
+++ b/c-api/src/capi_vm_hook_pointers.rs
@@ -108,6 +108,7 @@ pub struct vm_exec_vm_hook_c_func_pointers {
     pub managed_get_prev_block_random_seed_func_ptr: extern "C" fn(context: *mut c_void, result_handle: i32),
     pub managed_get_return_data_func_ptr: extern "C" fn(context: *mut c_void, result_id: i32, result_handle: i32),
     pub managed_get_multi_esdt_call_value_func_ptr: extern "C" fn(context: *mut c_void, multi_call_value_handle: i32),
+    pub managed_get_all_transfers_call_value_func_ptr: extern "C" fn(context: *mut c_void, value_handle: i32),
     pub managed_get_back_transfers_func_ptr: extern "C" fn(context: *mut c_void, esdt_transfers_value_handle: i32, egld_value_handle: i32),
     pub managed_get_esdt_balance_func_ptr: extern "C" fn(context: *mut c_void, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32),
     pub managed_get_esdt_token_data_func_ptr: extern "C" fn(context: *mut c_void, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32, properties_handle: i32, hash_handle: i32, name_handle: i32, attributes_handle: i32, creator_handle: i32, royalties_handle: i32, uris_handle: i32),

--- a/c-api/src/capi_vm_hooks.rs
+++ b/c-api/src/capi_vm_hooks.rs
@@ -431,6 +431,10 @@ impl multiversx_chain_vm_executor::VMHooks for CapiVMHooks {
         (self.c_func_pointers_ptr.managed_get_multi_esdt_call_value_func_ptr)(self.vm_hooks_ptr, multi_call_value_handle)
     }
 
+    fn managed_get_all_transfers_call_value(&self, value_handle: i32) {
+        (self.c_func_pointers_ptr.managed_get_all_transfers_call_value_func_ptr)(self.vm_hooks_ptr, value_handle)
+    }
+
     fn managed_get_back_transfers(&self, esdt_transfers_value_handle: i32, egld_value_handle: i32) {
         (self.c_func_pointers_ptr.managed_get_back_transfers_func_ptr)(self.vm_hooks_ptr, esdt_transfers_value_handle, egld_value_handle)
     }

--- a/vm-executor-wasmer/src/wasmer_imports.rs
+++ b/vm-executor-wasmer/src/wasmer_imports.rs
@@ -501,6 +501,11 @@ fn wasmer_import_managed_get_multi_esdt_call_value(env: &VMHooksWrapper, multi_c
 }
 
 #[rustfmt::skip]
+fn wasmer_import_managed_get_all_transfers_call_value(env: &VMHooksWrapper, value_handle: i32) {
+    env.vm_hooks.managed_get_all_transfers_call_value(value_handle)
+}
+
+#[rustfmt::skip]
 fn wasmer_import_managed_get_back_transfers(env: &VMHooksWrapper, esdt_transfers_value_handle: i32, egld_value_handle: i32) {
     env.vm_hooks.managed_get_back_transfers(esdt_transfers_value_handle, egld_value_handle)
 }
@@ -1461,6 +1466,7 @@ pub fn generate_import_object(store: &Store, env: &VMHooksWrapper) -> ImportObje
             "managedGetPrevBlockRandomSeed" => Function::new_native_with_env(store, env.clone(), wasmer_import_managed_get_prev_block_random_seed),
             "managedGetReturnData" => Function::new_native_with_env(store, env.clone(), wasmer_import_managed_get_return_data),
             "managedGetMultiESDTCallValue" => Function::new_native_with_env(store, env.clone(), wasmer_import_managed_get_multi_esdt_call_value),
+            "managedGetAllTransfersCallValue" => Function::new_native_with_env(store, env.clone(), wasmer_import_managed_get_all_transfers_call_value),
             "managedGetBackTransfers" => Function::new_native_with_env(store, env.clone(), wasmer_import_managed_get_back_transfers),
             "managedGetESDTBalance" => Function::new_native_with_env(store, env.clone(), wasmer_import_managed_get_esdt_balance),
             "managedGetESDTTokenData" => Function::new_native_with_env(store, env.clone(), wasmer_import_managed_get_esdt_token_data),

--- a/vm-executor/src/vm_hooks.rs
+++ b/vm-executor/src/vm_hooks.rs
@@ -111,6 +111,7 @@ pub trait VMHooks: core::fmt::Debug + 'static {
     fn managed_get_prev_block_random_seed(&self, result_handle: i32);
     fn managed_get_return_data(&self, result_id: i32, result_handle: i32);
     fn managed_get_multi_esdt_call_value(&self, multi_call_value_handle: i32);
+    fn managed_get_all_transfers_call_value(&self, value_handle: i32);
     fn managed_get_back_transfers(&self, esdt_transfers_value_handle: i32, egld_value_handle: i32);
     fn managed_get_esdt_balance(&self, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32);
     fn managed_get_esdt_token_data(&self, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32, properties_handle: i32, hash_handle: i32, name_handle: i32, attributes_handle: i32, creator_handle: i32, royalties_handle: i32, uris_handle: i32);
@@ -749,6 +750,10 @@ impl VMHooks for VMHooksDefault {
 
     fn managed_get_multi_esdt_call_value(&self, multi_call_value_handle: i32) {
         println!("Called: managed_get_multi_esdt_call_value");
+    }
+
+    fn managed_get_all_transfers_call_value(&self, value_handle: i32) {
+        println!("Called: managed_get_all_transfers_call_value");
     }
 
     fn managed_get_back_transfers(&self, esdt_transfers_value_handle: i32, egld_value_handle: i32) {


### PR DESCRIPTION
We currently have 2 VM hooks for incoming payments:
- `bigIntGetCallValue` gets the EGLD call value
- `managedGetMultiESDTCallValue` gets the ESDT tokens value as a list

However, as of Spica, EGLD can also be sent as a token.

This hook combines both in a single list, by creating a EGLD-000000 entry with the value of the call value.
