### PR TITLE
VMHooksLegacyAdapter converted to struct from trait, VMHooks legacy revert

### DIFF
--- a/c-api/src/capi_vm_hooks.rs
+++ b/c-api/src/capi_vm_hooks.rs
@@ -24,11 +24,11 @@ impl CapiVMHooks {
         }
     }
 
-    fn convert_mem_ptr(&mut self, mem_ptr: MemPtr) -> i32 {
+    fn convert_mem_ptr(&self, mem_ptr: MemPtr) -> i32 {
         mem_ptr as i32
     }
 
-    fn convert_mem_length(&mut self, mem_length: MemLength) -> i32 {
+    fn convert_mem_length(&self, mem_length: MemLength) -> i32 {
         mem_length as i32
     }
 }
@@ -39,1051 +39,1051 @@ impl multiversx_chain_vm_executor::VMHooksLegacy for CapiVMHooks {
         self.vm_hooks_ptr = vm_hooks_ptr;
     }
 
-    fn get_gas_left(&mut self) -> i64 {
+    fn get_gas_left(&self) -> i64 {
         (self.c_func_pointers_ptr.get_gas_left_func_ptr)(self.vm_hooks_ptr)
     }
 
-    fn get_sc_address(&mut self, result_offset: MemPtr) {
+    fn get_sc_address(&self, result_offset: MemPtr) {
         (self.c_func_pointers_ptr.get_sc_address_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(result_offset))
     }
 
-    fn get_owner_address(&mut self, result_offset: MemPtr) {
+    fn get_owner_address(&self, result_offset: MemPtr) {
         (self.c_func_pointers_ptr.get_owner_address_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(result_offset))
     }
 
-    fn get_shard_of_address(&mut self, address_offset: MemPtr) -> i32 {
+    fn get_shard_of_address(&self, address_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.get_shard_of_address_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(address_offset))
     }
 
-    fn is_smart_contract(&mut self, address_offset: MemPtr) -> i32 {
+    fn is_smart_contract(&self, address_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.is_smart_contract_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(address_offset))
     }
 
-    fn signal_error(&mut self, message_offset: MemPtr, message_length: MemLength) {
+    fn signal_error(&self, message_offset: MemPtr, message_length: MemLength) {
         (self.c_func_pointers_ptr.signal_error_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(message_offset), self.convert_mem_length(message_length))
     }
 
-    fn get_external_balance(&mut self, address_offset: MemPtr, result_offset: MemPtr) {
+    fn get_external_balance(&self, address_offset: MemPtr, result_offset: MemPtr) {
         (self.c_func_pointers_ptr.get_external_balance_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(address_offset), self.convert_mem_ptr(result_offset))
     }
 
-    fn get_block_hash(&mut self, nonce: i64, result_offset: MemPtr) -> i32 {
+    fn get_block_hash(&self, nonce: i64, result_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.get_block_hash_func_ptr)(self.vm_hooks_ptr, nonce, self.convert_mem_ptr(result_offset))
     }
 
-    fn get_esdt_balance(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, result_offset: MemPtr) -> i32 {
+    fn get_esdt_balance(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, result_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.get_esdt_balance_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(address_offset), self.convert_mem_ptr(token_id_offset), self.convert_mem_length(token_id_len), nonce, self.convert_mem_ptr(result_offset))
     }
 
-    fn get_esdt_nft_name_length(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
+    fn get_esdt_nft_name_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
         (self.c_func_pointers_ptr.get_esdt_nft_name_length_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(address_offset), self.convert_mem_ptr(token_id_offset), self.convert_mem_length(token_id_len), nonce)
     }
 
-    fn get_esdt_nft_attribute_length(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
+    fn get_esdt_nft_attribute_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
         (self.c_func_pointers_ptr.get_esdt_nft_attribute_length_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(address_offset), self.convert_mem_ptr(token_id_offset), self.convert_mem_length(token_id_len), nonce)
     }
 
-    fn get_esdt_nft_uri_length(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
+    fn get_esdt_nft_uri_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
         (self.c_func_pointers_ptr.get_esdt_nft_uri_length_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(address_offset), self.convert_mem_ptr(token_id_offset), self.convert_mem_length(token_id_len), nonce)
     }
 
-    fn get_esdt_token_data(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, value_handle: i32, properties_offset: MemPtr, hash_offset: MemPtr, name_offset: MemPtr, attributes_offset: MemPtr, creator_offset: MemPtr, royalties_handle: i32, uris_offset: MemPtr) -> i32 {
+    fn get_esdt_token_data(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, value_handle: i32, properties_offset: MemPtr, hash_offset: MemPtr, name_offset: MemPtr, attributes_offset: MemPtr, creator_offset: MemPtr, royalties_handle: i32, uris_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.get_esdt_token_data_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(address_offset), self.convert_mem_ptr(token_id_offset), self.convert_mem_length(token_id_len), nonce, value_handle, self.convert_mem_ptr(properties_offset), self.convert_mem_ptr(hash_offset), self.convert_mem_ptr(name_offset), self.convert_mem_ptr(attributes_offset), self.convert_mem_ptr(creator_offset), royalties_handle, self.convert_mem_ptr(uris_offset))
     }
 
-    fn get_esdt_local_roles(&mut self, token_id_handle: i32) -> i64 {
+    fn get_esdt_local_roles(&self, token_id_handle: i32) -> i64 {
         (self.c_func_pointers_ptr.get_esdt_local_roles_func_ptr)(self.vm_hooks_ptr, token_id_handle)
     }
 
-    fn validate_token_identifier(&mut self, token_id_handle: i32) -> i32 {
+    fn validate_token_identifier(&self, token_id_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.validate_token_identifier_func_ptr)(self.vm_hooks_ptr, token_id_handle)
     }
 
-    fn transfer_value(&mut self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, length: MemLength) -> i32 {
+    fn transfer_value(&self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, length: MemLength) -> i32 {
         (self.c_func_pointers_ptr.transfer_value_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(dest_offset), self.convert_mem_ptr(value_offset), self.convert_mem_ptr(data_offset), self.convert_mem_length(length))
     }
 
-    fn transfer_value_execute(&mut self, dest_offset: MemPtr, value_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+    fn transfer_value_execute(&self, dest_offset: MemPtr, value_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.transfer_value_execute_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(dest_offset), self.convert_mem_ptr(value_offset), gas_limit, self.convert_mem_ptr(function_offset), self.convert_mem_length(function_length), num_arguments, self.convert_mem_ptr(arguments_length_offset), self.convert_mem_ptr(data_offset))
     }
 
-    fn transfer_esdt_execute(&mut self, dest_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, value_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+    fn transfer_esdt_execute(&self, dest_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, value_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.transfer_esdt_execute_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(dest_offset), self.convert_mem_ptr(token_id_offset), self.convert_mem_length(token_id_len), self.convert_mem_ptr(value_offset), gas_limit, self.convert_mem_ptr(function_offset), self.convert_mem_length(function_length), num_arguments, self.convert_mem_ptr(arguments_length_offset), self.convert_mem_ptr(data_offset))
     }
 
-    fn transfer_esdt_nft_execute(&mut self, dest_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, value_offset: MemPtr, nonce: i64, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+    fn transfer_esdt_nft_execute(&self, dest_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, value_offset: MemPtr, nonce: i64, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.transfer_esdt_nft_execute_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(dest_offset), self.convert_mem_ptr(token_id_offset), self.convert_mem_length(token_id_len), self.convert_mem_ptr(value_offset), nonce, gas_limit, self.convert_mem_ptr(function_offset), self.convert_mem_length(function_length), num_arguments, self.convert_mem_ptr(arguments_length_offset), self.convert_mem_ptr(data_offset))
     }
 
-    fn multi_transfer_esdt_nft_execute(&mut self, dest_offset: MemPtr, num_token_transfers: i32, token_transfers_args_length_offset: MemPtr, token_transfer_data_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+    fn multi_transfer_esdt_nft_execute(&self, dest_offset: MemPtr, num_token_transfers: i32, token_transfers_args_length_offset: MemPtr, token_transfer_data_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.multi_transfer_esdt_nft_execute_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(dest_offset), num_token_transfers, self.convert_mem_ptr(token_transfers_args_length_offset), self.convert_mem_ptr(token_transfer_data_offset), gas_limit, self.convert_mem_ptr(function_offset), self.convert_mem_length(function_length), num_arguments, self.convert_mem_ptr(arguments_length_offset), self.convert_mem_ptr(data_offset))
     }
 
-    fn create_async_call(&mut self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, data_length: MemLength, success_offset: MemPtr, success_length: MemLength, error_offset: MemPtr, error_length: MemLength, gas: i64, extra_gas_for_callback: i64) -> i32 {
+    fn create_async_call(&self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, data_length: MemLength, success_offset: MemPtr, success_length: MemLength, error_offset: MemPtr, error_length: MemLength, gas: i64, extra_gas_for_callback: i64) -> i32 {
         (self.c_func_pointers_ptr.create_async_call_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(dest_offset), self.convert_mem_ptr(value_offset), self.convert_mem_ptr(data_offset), self.convert_mem_length(data_length), self.convert_mem_ptr(success_offset), self.convert_mem_length(success_length), self.convert_mem_ptr(error_offset), self.convert_mem_length(error_length), gas, extra_gas_for_callback)
     }
 
-    fn set_async_context_callback(&mut self, callback: MemPtr, callback_length: MemLength, data: MemPtr, data_length: MemLength, gas: i64) -> i32 {
+    fn set_async_context_callback(&self, callback: MemPtr, callback_length: MemLength, data: MemPtr, data_length: MemLength, gas: i64) -> i32 {
         (self.c_func_pointers_ptr.set_async_context_callback_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(callback), self.convert_mem_length(callback_length), self.convert_mem_ptr(data), self.convert_mem_length(data_length), gas)
     }
 
-    fn upgrade_contract(&mut self, dest_offset: MemPtr, gas_limit: i64, value_offset: MemPtr, code_offset: MemPtr, code_metadata_offset: MemPtr, length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) {
+    fn upgrade_contract(&self, dest_offset: MemPtr, gas_limit: i64, value_offset: MemPtr, code_offset: MemPtr, code_metadata_offset: MemPtr, length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) {
         (self.c_func_pointers_ptr.upgrade_contract_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(dest_offset), gas_limit, self.convert_mem_ptr(value_offset), self.convert_mem_ptr(code_offset), self.convert_mem_ptr(code_metadata_offset), self.convert_mem_length(length), num_arguments, self.convert_mem_ptr(arguments_length_offset), self.convert_mem_ptr(data_offset))
     }
 
-    fn upgrade_from_source_contract(&mut self, dest_offset: MemPtr, gas_limit: i64, value_offset: MemPtr, source_contract_address_offset: MemPtr, code_metadata_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) {
+    fn upgrade_from_source_contract(&self, dest_offset: MemPtr, gas_limit: i64, value_offset: MemPtr, source_contract_address_offset: MemPtr, code_metadata_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) {
         (self.c_func_pointers_ptr.upgrade_from_source_contract_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(dest_offset), gas_limit, self.convert_mem_ptr(value_offset), self.convert_mem_ptr(source_contract_address_offset), self.convert_mem_ptr(code_metadata_offset), num_arguments, self.convert_mem_ptr(arguments_length_offset), self.convert_mem_ptr(data_offset))
     }
 
-    fn delete_contract(&mut self, dest_offset: MemPtr, gas_limit: i64, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) {
+    fn delete_contract(&self, dest_offset: MemPtr, gas_limit: i64, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) {
         (self.c_func_pointers_ptr.delete_contract_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(dest_offset), gas_limit, num_arguments, self.convert_mem_ptr(arguments_length_offset), self.convert_mem_ptr(data_offset))
     }
 
-    fn async_call(&mut self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, length: MemLength) {
+    fn async_call(&self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, length: MemLength) {
         (self.c_func_pointers_ptr.async_call_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(dest_offset), self.convert_mem_ptr(value_offset), self.convert_mem_ptr(data_offset), self.convert_mem_length(length))
     }
 
-    fn get_argument_length(&mut self, id: i32) -> i32 {
+    fn get_argument_length(&self, id: i32) -> i32 {
         (self.c_func_pointers_ptr.get_argument_length_func_ptr)(self.vm_hooks_ptr, id)
     }
 
-    fn get_argument(&mut self, id: i32, arg_offset: MemPtr) -> i32 {
+    fn get_argument(&self, id: i32, arg_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.get_argument_func_ptr)(self.vm_hooks_ptr, id, self.convert_mem_ptr(arg_offset))
     }
 
-    fn get_function(&mut self, function_offset: MemPtr) -> i32 {
+    fn get_function(&self, function_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.get_function_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(function_offset))
     }
 
-    fn get_num_arguments(&mut self) -> i32 {
+    fn get_num_arguments(&self) -> i32 {
         (self.c_func_pointers_ptr.get_num_arguments_func_ptr)(self.vm_hooks_ptr)
     }
 
-    fn storage_store(&mut self, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr, data_length: MemLength) -> i32 {
+    fn storage_store(&self, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr, data_length: MemLength) -> i32 {
         (self.c_func_pointers_ptr.storage_store_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(key_offset), self.convert_mem_length(key_length), self.convert_mem_ptr(data_offset), self.convert_mem_length(data_length))
     }
 
-    fn storage_load_length(&mut self, key_offset: MemPtr, key_length: MemLength) -> i32 {
+    fn storage_load_length(&self, key_offset: MemPtr, key_length: MemLength) -> i32 {
         (self.c_func_pointers_ptr.storage_load_length_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(key_offset), self.convert_mem_length(key_length))
     }
 
-    fn storage_load_from_address(&mut self, address_offset: MemPtr, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr) -> i32 {
+    fn storage_load_from_address(&self, address_offset: MemPtr, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.storage_load_from_address_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(address_offset), self.convert_mem_ptr(key_offset), self.convert_mem_length(key_length), self.convert_mem_ptr(data_offset))
     }
 
-    fn storage_load(&mut self, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr) -> i32 {
+    fn storage_load(&self, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.storage_load_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(key_offset), self.convert_mem_length(key_length), self.convert_mem_ptr(data_offset))
     }
 
-    fn set_storage_lock(&mut self, key_offset: MemPtr, key_length: MemLength, lock_timestamp: i64) -> i32 {
+    fn set_storage_lock(&self, key_offset: MemPtr, key_length: MemLength, lock_timestamp: i64) -> i32 {
         (self.c_func_pointers_ptr.set_storage_lock_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(key_offset), self.convert_mem_length(key_length), lock_timestamp)
     }
 
-    fn get_storage_lock(&mut self, key_offset: MemPtr, key_length: MemLength) -> i64 {
+    fn get_storage_lock(&self, key_offset: MemPtr, key_length: MemLength) -> i64 {
         (self.c_func_pointers_ptr.get_storage_lock_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(key_offset), self.convert_mem_length(key_length))
     }
 
-    fn is_storage_locked(&mut self, key_offset: MemPtr, key_length: MemLength) -> i32 {
+    fn is_storage_locked(&self, key_offset: MemPtr, key_length: MemLength) -> i32 {
         (self.c_func_pointers_ptr.is_storage_locked_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(key_offset), self.convert_mem_length(key_length))
     }
 
-    fn clear_storage_lock(&mut self, key_offset: MemPtr, key_length: MemLength) -> i32 {
+    fn clear_storage_lock(&self, key_offset: MemPtr, key_length: MemLength) -> i32 {
         (self.c_func_pointers_ptr.clear_storage_lock_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(key_offset), self.convert_mem_length(key_length))
     }
 
-    fn get_caller(&mut self, result_offset: MemPtr) {
+    fn get_caller(&self, result_offset: MemPtr) {
         (self.c_func_pointers_ptr.get_caller_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(result_offset))
     }
 
-    fn check_no_payment(&mut self) {
+    fn check_no_payment(&self) {
         (self.c_func_pointers_ptr.check_no_payment_func_ptr)(self.vm_hooks_ptr)
     }
 
-    fn get_call_value(&mut self, result_offset: MemPtr) -> i32 {
+    fn get_call_value(&self, result_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.get_call_value_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(result_offset))
     }
 
-    fn get_esdt_value(&mut self, result_offset: MemPtr) -> i32 {
+    fn get_esdt_value(&self, result_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.get_esdt_value_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(result_offset))
     }
 
-    fn get_esdt_value_by_index(&mut self, result_offset: MemPtr, index: i32) -> i32 {
+    fn get_esdt_value_by_index(&self, result_offset: MemPtr, index: i32) -> i32 {
         (self.c_func_pointers_ptr.get_esdt_value_by_index_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(result_offset), index)
     }
 
-    fn get_esdt_token_name(&mut self, result_offset: MemPtr) -> i32 {
+    fn get_esdt_token_name(&self, result_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.get_esdt_token_name_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(result_offset))
     }
 
-    fn get_esdt_token_name_by_index(&mut self, result_offset: MemPtr, index: i32) -> i32 {
+    fn get_esdt_token_name_by_index(&self, result_offset: MemPtr, index: i32) -> i32 {
         (self.c_func_pointers_ptr.get_esdt_token_name_by_index_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(result_offset), index)
     }
 
-    fn get_esdt_token_nonce(&mut self) -> i64 {
+    fn get_esdt_token_nonce(&self) -> i64 {
         (self.c_func_pointers_ptr.get_esdt_token_nonce_func_ptr)(self.vm_hooks_ptr)
     }
 
-    fn get_esdt_token_nonce_by_index(&mut self, index: i32) -> i64 {
+    fn get_esdt_token_nonce_by_index(&self, index: i32) -> i64 {
         (self.c_func_pointers_ptr.get_esdt_token_nonce_by_index_func_ptr)(self.vm_hooks_ptr, index)
     }
 
-    fn get_current_esdt_nft_nonce(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength) -> i64 {
+    fn get_current_esdt_nft_nonce(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength) -> i64 {
         (self.c_func_pointers_ptr.get_current_esdt_nft_nonce_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(address_offset), self.convert_mem_ptr(token_id_offset), self.convert_mem_length(token_id_len))
     }
 
-    fn get_esdt_token_type(&mut self) -> i32 {
+    fn get_esdt_token_type(&self) -> i32 {
         (self.c_func_pointers_ptr.get_esdt_token_type_func_ptr)(self.vm_hooks_ptr)
     }
 
-    fn get_esdt_token_type_by_index(&mut self, index: i32) -> i32 {
+    fn get_esdt_token_type_by_index(&self, index: i32) -> i32 {
         (self.c_func_pointers_ptr.get_esdt_token_type_by_index_func_ptr)(self.vm_hooks_ptr, index)
     }
 
-    fn get_num_esdt_transfers(&mut self) -> i32 {
+    fn get_num_esdt_transfers(&self) -> i32 {
         (self.c_func_pointers_ptr.get_num_esdt_transfers_func_ptr)(self.vm_hooks_ptr)
     }
 
-    fn get_call_value_token_name(&mut self, call_value_offset: MemPtr, token_name_offset: MemPtr) -> i32 {
+    fn get_call_value_token_name(&self, call_value_offset: MemPtr, token_name_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.get_call_value_token_name_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(call_value_offset), self.convert_mem_ptr(token_name_offset))
     }
 
-    fn get_call_value_token_name_by_index(&mut self, call_value_offset: MemPtr, token_name_offset: MemPtr, index: i32) -> i32 {
+    fn get_call_value_token_name_by_index(&self, call_value_offset: MemPtr, token_name_offset: MemPtr, index: i32) -> i32 {
         (self.c_func_pointers_ptr.get_call_value_token_name_by_index_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(call_value_offset), self.convert_mem_ptr(token_name_offset), index)
     }
 
-    fn is_reserved_function_name(&mut self, name_handle: i32) -> i32 {
+    fn is_reserved_function_name(&self, name_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.is_reserved_function_name_func_ptr)(self.vm_hooks_ptr, name_handle)
     }
 
-    fn write_log(&mut self, data_pointer: MemPtr, data_length: MemLength, topic_ptr: MemPtr, num_topics: i32) {
+    fn write_log(&self, data_pointer: MemPtr, data_length: MemLength, topic_ptr: MemPtr, num_topics: i32) {
         (self.c_func_pointers_ptr.write_log_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(data_pointer), self.convert_mem_length(data_length), self.convert_mem_ptr(topic_ptr), num_topics)
     }
 
-    fn write_event_log(&mut self, num_topics: i32, topic_lengths_offset: MemPtr, topic_offset: MemPtr, data_offset: MemPtr, data_length: MemLength) {
+    fn write_event_log(&self, num_topics: i32, topic_lengths_offset: MemPtr, topic_offset: MemPtr, data_offset: MemPtr, data_length: MemLength) {
         (self.c_func_pointers_ptr.write_event_log_func_ptr)(self.vm_hooks_ptr, num_topics, self.convert_mem_ptr(topic_lengths_offset), self.convert_mem_ptr(topic_offset), self.convert_mem_ptr(data_offset), self.convert_mem_length(data_length))
     }
 
-    fn get_block_timestamp(&mut self) -> i64 {
+    fn get_block_timestamp(&self) -> i64 {
         (self.c_func_pointers_ptr.get_block_timestamp_func_ptr)(self.vm_hooks_ptr)
     }
 
-    fn get_block_nonce(&mut self) -> i64 {
+    fn get_block_nonce(&self) -> i64 {
         (self.c_func_pointers_ptr.get_block_nonce_func_ptr)(self.vm_hooks_ptr)
     }
 
-    fn get_block_round(&mut self) -> i64 {
+    fn get_block_round(&self) -> i64 {
         (self.c_func_pointers_ptr.get_block_round_func_ptr)(self.vm_hooks_ptr)
     }
 
-    fn get_block_epoch(&mut self) -> i64 {
+    fn get_block_epoch(&self) -> i64 {
         (self.c_func_pointers_ptr.get_block_epoch_func_ptr)(self.vm_hooks_ptr)
     }
 
-    fn get_block_random_seed(&mut self, pointer: MemPtr) {
+    fn get_block_random_seed(&self, pointer: MemPtr) {
         (self.c_func_pointers_ptr.get_block_random_seed_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(pointer))
     }
 
-    fn get_state_root_hash(&mut self, pointer: MemPtr) {
+    fn get_state_root_hash(&self, pointer: MemPtr) {
         (self.c_func_pointers_ptr.get_state_root_hash_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(pointer))
     }
 
-    fn get_prev_block_timestamp(&mut self) -> i64 {
+    fn get_prev_block_timestamp(&self) -> i64 {
         (self.c_func_pointers_ptr.get_prev_block_timestamp_func_ptr)(self.vm_hooks_ptr)
     }
 
-    fn get_prev_block_nonce(&mut self) -> i64 {
+    fn get_prev_block_nonce(&self) -> i64 {
         (self.c_func_pointers_ptr.get_prev_block_nonce_func_ptr)(self.vm_hooks_ptr)
     }
 
-    fn get_prev_block_round(&mut self) -> i64 {
+    fn get_prev_block_round(&self) -> i64 {
         (self.c_func_pointers_ptr.get_prev_block_round_func_ptr)(self.vm_hooks_ptr)
     }
 
-    fn get_prev_block_epoch(&mut self) -> i64 {
+    fn get_prev_block_epoch(&self) -> i64 {
         (self.c_func_pointers_ptr.get_prev_block_epoch_func_ptr)(self.vm_hooks_ptr)
     }
 
-    fn get_prev_block_random_seed(&mut self, pointer: MemPtr) {
+    fn get_prev_block_random_seed(&self, pointer: MemPtr) {
         (self.c_func_pointers_ptr.get_prev_block_random_seed_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(pointer))
     }
 
-    fn finish(&mut self, pointer: MemPtr, length: MemLength) {
+    fn finish(&self, pointer: MemPtr, length: MemLength) {
         (self.c_func_pointers_ptr.finish_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(pointer), self.convert_mem_length(length))
     }
 
-    fn execute_on_same_context(&mut self, gas_limit: i64, address_offset: MemPtr, value_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+    fn execute_on_same_context(&self, gas_limit: i64, address_offset: MemPtr, value_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.execute_on_same_context_func_ptr)(self.vm_hooks_ptr, gas_limit, self.convert_mem_ptr(address_offset), self.convert_mem_ptr(value_offset), self.convert_mem_ptr(function_offset), self.convert_mem_length(function_length), num_arguments, self.convert_mem_ptr(arguments_length_offset), self.convert_mem_ptr(data_offset))
     }
 
-    fn execute_on_dest_context(&mut self, gas_limit: i64, address_offset: MemPtr, value_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+    fn execute_on_dest_context(&self, gas_limit: i64, address_offset: MemPtr, value_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.execute_on_dest_context_func_ptr)(self.vm_hooks_ptr, gas_limit, self.convert_mem_ptr(address_offset), self.convert_mem_ptr(value_offset), self.convert_mem_ptr(function_offset), self.convert_mem_length(function_length), num_arguments, self.convert_mem_ptr(arguments_length_offset), self.convert_mem_ptr(data_offset))
     }
 
-    fn execute_read_only(&mut self, gas_limit: i64, address_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+    fn execute_read_only(&self, gas_limit: i64, address_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.execute_read_only_func_ptr)(self.vm_hooks_ptr, gas_limit, self.convert_mem_ptr(address_offset), self.convert_mem_ptr(function_offset), self.convert_mem_length(function_length), num_arguments, self.convert_mem_ptr(arguments_length_offset), self.convert_mem_ptr(data_offset))
     }
 
-    fn create_contract(&mut self, gas_limit: i64, value_offset: MemPtr, code_offset: MemPtr, code_metadata_offset: MemPtr, length: MemLength, result_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+    fn create_contract(&self, gas_limit: i64, value_offset: MemPtr, code_offset: MemPtr, code_metadata_offset: MemPtr, length: MemLength, result_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.create_contract_func_ptr)(self.vm_hooks_ptr, gas_limit, self.convert_mem_ptr(value_offset), self.convert_mem_ptr(code_offset), self.convert_mem_ptr(code_metadata_offset), self.convert_mem_length(length), self.convert_mem_ptr(result_offset), num_arguments, self.convert_mem_ptr(arguments_length_offset), self.convert_mem_ptr(data_offset))
     }
 
-    fn deploy_from_source_contract(&mut self, gas_limit: i64, value_offset: MemPtr, source_contract_address_offset: MemPtr, code_metadata_offset: MemPtr, result_address_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+    fn deploy_from_source_contract(&self, gas_limit: i64, value_offset: MemPtr, source_contract_address_offset: MemPtr, code_metadata_offset: MemPtr, result_address_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.deploy_from_source_contract_func_ptr)(self.vm_hooks_ptr, gas_limit, self.convert_mem_ptr(value_offset), self.convert_mem_ptr(source_contract_address_offset), self.convert_mem_ptr(code_metadata_offset), self.convert_mem_ptr(result_address_offset), num_arguments, self.convert_mem_ptr(arguments_length_offset), self.convert_mem_ptr(data_offset))
     }
 
-    fn get_num_return_data(&mut self) -> i32 {
+    fn get_num_return_data(&self) -> i32 {
         (self.c_func_pointers_ptr.get_num_return_data_func_ptr)(self.vm_hooks_ptr)
     }
 
-    fn get_return_data_size(&mut self, result_id: i32) -> i32 {
+    fn get_return_data_size(&self, result_id: i32) -> i32 {
         (self.c_func_pointers_ptr.get_return_data_size_func_ptr)(self.vm_hooks_ptr, result_id)
     }
 
-    fn get_return_data(&mut self, result_id: i32, data_offset: MemPtr) -> i32 {
+    fn get_return_data(&self, result_id: i32, data_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.get_return_data_func_ptr)(self.vm_hooks_ptr, result_id, self.convert_mem_ptr(data_offset))
     }
 
-    fn clean_return_data(&mut self) {
+    fn clean_return_data(&self) {
         (self.c_func_pointers_ptr.clean_return_data_func_ptr)(self.vm_hooks_ptr)
     }
 
-    fn delete_from_return_data(&mut self, result_id: i32) {
+    fn delete_from_return_data(&self, result_id: i32) {
         (self.c_func_pointers_ptr.delete_from_return_data_func_ptr)(self.vm_hooks_ptr, result_id)
     }
 
-    fn get_original_tx_hash(&mut self, data_offset: MemPtr) {
+    fn get_original_tx_hash(&self, data_offset: MemPtr) {
         (self.c_func_pointers_ptr.get_original_tx_hash_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(data_offset))
     }
 
-    fn get_current_tx_hash(&mut self, data_offset: MemPtr) {
+    fn get_current_tx_hash(&self, data_offset: MemPtr) {
         (self.c_func_pointers_ptr.get_current_tx_hash_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(data_offset))
     }
 
-    fn get_prev_tx_hash(&mut self, data_offset: MemPtr) {
+    fn get_prev_tx_hash(&self, data_offset: MemPtr) {
         (self.c_func_pointers_ptr.get_prev_tx_hash_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(data_offset))
     }
 
-    fn managed_sc_address(&mut self, destination_handle: i32) {
+    fn managed_sc_address(&self, destination_handle: i32) {
         (self.c_func_pointers_ptr.managed_sc_address_func_ptr)(self.vm_hooks_ptr, destination_handle)
     }
 
-    fn managed_owner_address(&mut self, destination_handle: i32) {
+    fn managed_owner_address(&self, destination_handle: i32) {
         (self.c_func_pointers_ptr.managed_owner_address_func_ptr)(self.vm_hooks_ptr, destination_handle)
     }
 
-    fn managed_caller(&mut self, destination_handle: i32) {
+    fn managed_caller(&self, destination_handle: i32) {
         (self.c_func_pointers_ptr.managed_caller_func_ptr)(self.vm_hooks_ptr, destination_handle)
     }
 
-    fn managed_get_original_caller_addr(&mut self, destination_handle: i32) {
+    fn managed_get_original_caller_addr(&self, destination_handle: i32) {
         (self.c_func_pointers_ptr.managed_get_original_caller_addr_func_ptr)(self.vm_hooks_ptr, destination_handle)
     }
 
-    fn managed_get_relayer_addr(&mut self, destination_handle: i32) {
+    fn managed_get_relayer_addr(&self, destination_handle: i32) {
         (self.c_func_pointers_ptr.managed_get_relayer_addr_func_ptr)(self.vm_hooks_ptr, destination_handle)
     }
 
-    fn managed_signal_error(&mut self, err_handle: i32) {
+    fn managed_signal_error(&self, err_handle: i32) {
         (self.c_func_pointers_ptr.managed_signal_error_func_ptr)(self.vm_hooks_ptr, err_handle)
     }
 
-    fn managed_write_log(&mut self, topics_handle: i32, data_handle: i32) {
+    fn managed_write_log(&self, topics_handle: i32, data_handle: i32) {
         (self.c_func_pointers_ptr.managed_write_log_func_ptr)(self.vm_hooks_ptr, topics_handle, data_handle)
     }
 
-    fn managed_get_original_tx_hash(&mut self, result_handle: i32) {
+    fn managed_get_original_tx_hash(&self, result_handle: i32) {
         (self.c_func_pointers_ptr.managed_get_original_tx_hash_func_ptr)(self.vm_hooks_ptr, result_handle)
     }
 
-    fn managed_get_state_root_hash(&mut self, result_handle: i32) {
+    fn managed_get_state_root_hash(&self, result_handle: i32) {
         (self.c_func_pointers_ptr.managed_get_state_root_hash_func_ptr)(self.vm_hooks_ptr, result_handle)
     }
 
-    fn managed_get_block_random_seed(&mut self, result_handle: i32) {
+    fn managed_get_block_random_seed(&self, result_handle: i32) {
         (self.c_func_pointers_ptr.managed_get_block_random_seed_func_ptr)(self.vm_hooks_ptr, result_handle)
     }
 
-    fn managed_get_prev_block_random_seed(&mut self, result_handle: i32) {
+    fn managed_get_prev_block_random_seed(&self, result_handle: i32) {
         (self.c_func_pointers_ptr.managed_get_prev_block_random_seed_func_ptr)(self.vm_hooks_ptr, result_handle)
     }
 
-    fn managed_get_return_data(&mut self, result_id: i32, result_handle: i32) {
+    fn managed_get_return_data(&self, result_id: i32, result_handle: i32) {
         (self.c_func_pointers_ptr.managed_get_return_data_func_ptr)(self.vm_hooks_ptr, result_id, result_handle)
     }
 
-    fn managed_get_multi_esdt_call_value(&mut self, multi_call_value_handle: i32) {
+    fn managed_get_multi_esdt_call_value(&self, multi_call_value_handle: i32) {
         (self.c_func_pointers_ptr.managed_get_multi_esdt_call_value_func_ptr)(self.vm_hooks_ptr, multi_call_value_handle)
     }
 
-    fn managed_get_back_transfers(&mut self, esdt_transfers_value_handle: i32, egld_value_handle: i32) {
+    fn managed_get_back_transfers(&self, esdt_transfers_value_handle: i32, egld_value_handle: i32) {
         (self.c_func_pointers_ptr.managed_get_back_transfers_func_ptr)(self.vm_hooks_ptr, esdt_transfers_value_handle, egld_value_handle)
     }
 
-    fn managed_get_esdt_balance(&mut self, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32) {
+    fn managed_get_esdt_balance(&self, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32) {
         (self.c_func_pointers_ptr.managed_get_esdt_balance_func_ptr)(self.vm_hooks_ptr, address_handle, token_id_handle, nonce, value_handle)
     }
 
-    fn managed_get_esdt_token_data(&mut self, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32, properties_handle: i32, hash_handle: i32, name_handle: i32, attributes_handle: i32, creator_handle: i32, royalties_handle: i32, uris_handle: i32) {
+    fn managed_get_esdt_token_data(&self, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32, properties_handle: i32, hash_handle: i32, name_handle: i32, attributes_handle: i32, creator_handle: i32, royalties_handle: i32, uris_handle: i32) {
         (self.c_func_pointers_ptr.managed_get_esdt_token_data_func_ptr)(self.vm_hooks_ptr, address_handle, token_id_handle, nonce, value_handle, properties_handle, hash_handle, name_handle, attributes_handle, creator_handle, royalties_handle, uris_handle)
     }
 
-    fn managed_async_call(&mut self, dest_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32) {
+    fn managed_async_call(&self, dest_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32) {
         (self.c_func_pointers_ptr.managed_async_call_func_ptr)(self.vm_hooks_ptr, dest_handle, value_handle, function_handle, arguments_handle)
     }
 
-    fn managed_create_async_call(&mut self, dest_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, success_offset: MemPtr, success_length: MemLength, error_offset: MemPtr, error_length: MemLength, gas: i64, extra_gas_for_callback: i64, callback_closure_handle: i32) -> i32 {
+    fn managed_create_async_call(&self, dest_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, success_offset: MemPtr, success_length: MemLength, error_offset: MemPtr, error_length: MemLength, gas: i64, extra_gas_for_callback: i64, callback_closure_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_create_async_call_func_ptr)(self.vm_hooks_ptr, dest_handle, value_handle, function_handle, arguments_handle, self.convert_mem_ptr(success_offset), self.convert_mem_length(success_length), self.convert_mem_ptr(error_offset), self.convert_mem_length(error_length), gas, extra_gas_for_callback, callback_closure_handle)
     }
 
-    fn managed_get_callback_closure(&mut self, callback_closure_handle: i32) {
+    fn managed_get_callback_closure(&self, callback_closure_handle: i32) {
         (self.c_func_pointers_ptr.managed_get_callback_closure_func_ptr)(self.vm_hooks_ptr, callback_closure_handle)
     }
 
-    fn managed_upgrade_from_source_contract(&mut self, dest_handle: i32, gas: i64, value_handle: i32, address_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_handle: i32) {
+    fn managed_upgrade_from_source_contract(&self, dest_handle: i32, gas: i64, value_handle: i32, address_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_handle: i32) {
         (self.c_func_pointers_ptr.managed_upgrade_from_source_contract_func_ptr)(self.vm_hooks_ptr, dest_handle, gas, value_handle, address_handle, code_metadata_handle, arguments_handle, result_handle)
     }
 
-    fn managed_upgrade_contract(&mut self, dest_handle: i32, gas: i64, value_handle: i32, code_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_handle: i32) {
+    fn managed_upgrade_contract(&self, dest_handle: i32, gas: i64, value_handle: i32, code_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_handle: i32) {
         (self.c_func_pointers_ptr.managed_upgrade_contract_func_ptr)(self.vm_hooks_ptr, dest_handle, gas, value_handle, code_handle, code_metadata_handle, arguments_handle, result_handle)
     }
 
-    fn managed_delete_contract(&mut self, dest_handle: i32, gas_limit: i64, arguments_handle: i32) {
+    fn managed_delete_contract(&self, dest_handle: i32, gas_limit: i64, arguments_handle: i32) {
         (self.c_func_pointers_ptr.managed_delete_contract_func_ptr)(self.vm_hooks_ptr, dest_handle, gas_limit, arguments_handle)
     }
 
-    fn managed_deploy_from_source_contract(&mut self, gas: i64, value_handle: i32, address_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_address_handle: i32, result_handle: i32) -> i32 {
+    fn managed_deploy_from_source_contract(&self, gas: i64, value_handle: i32, address_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_address_handle: i32, result_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_deploy_from_source_contract_func_ptr)(self.vm_hooks_ptr, gas, value_handle, address_handle, code_metadata_handle, arguments_handle, result_address_handle, result_handle)
     }
 
-    fn managed_create_contract(&mut self, gas: i64, value_handle: i32, code_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_address_handle: i32, result_handle: i32) -> i32 {
+    fn managed_create_contract(&self, gas: i64, value_handle: i32, code_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_address_handle: i32, result_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_create_contract_func_ptr)(self.vm_hooks_ptr, gas, value_handle, code_handle, code_metadata_handle, arguments_handle, result_address_handle, result_handle)
     }
 
-    fn managed_execute_read_only(&mut self, gas: i64, address_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
+    fn managed_execute_read_only(&self, gas: i64, address_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_execute_read_only_func_ptr)(self.vm_hooks_ptr, gas, address_handle, function_handle, arguments_handle, result_handle)
     }
 
-    fn managed_execute_on_same_context(&mut self, gas: i64, address_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
+    fn managed_execute_on_same_context(&self, gas: i64, address_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_execute_on_same_context_func_ptr)(self.vm_hooks_ptr, gas, address_handle, value_handle, function_handle, arguments_handle, result_handle)
     }
 
-    fn managed_execute_on_dest_context(&mut self, gas: i64, address_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
+    fn managed_execute_on_dest_context(&self, gas: i64, address_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_execute_on_dest_context_func_ptr)(self.vm_hooks_ptr, gas, address_handle, value_handle, function_handle, arguments_handle, result_handle)
     }
 
-    fn managed_multi_transfer_esdt_nft_execute(&mut self, dst_handle: i32, token_transfers_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
+    fn managed_multi_transfer_esdt_nft_execute(&self, dst_handle: i32, token_transfers_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_multi_transfer_esdt_nft_execute_func_ptr)(self.vm_hooks_ptr, dst_handle, token_transfers_handle, gas_limit, function_handle, arguments_handle)
     }
 
-    fn managed_multi_transfer_esdt_nft_execute_by_user(&mut self, user_handle: i32, dst_handle: i32, token_transfers_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
+    fn managed_multi_transfer_esdt_nft_execute_by_user(&self, user_handle: i32, dst_handle: i32, token_transfers_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_multi_transfer_esdt_nft_execute_by_user_func_ptr)(self.vm_hooks_ptr, user_handle, dst_handle, token_transfers_handle, gas_limit, function_handle, arguments_handle)
     }
 
-    fn managed_transfer_value_execute(&mut self, dst_handle: i32, value_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
+    fn managed_transfer_value_execute(&self, dst_handle: i32, value_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_transfer_value_execute_func_ptr)(self.vm_hooks_ptr, dst_handle, value_handle, gas_limit, function_handle, arguments_handle)
     }
 
-    fn managed_is_esdt_frozen(&mut self, address_handle: i32, token_id_handle: i32, nonce: i64) -> i32 {
+    fn managed_is_esdt_frozen(&self, address_handle: i32, token_id_handle: i32, nonce: i64) -> i32 {
         (self.c_func_pointers_ptr.managed_is_esdt_frozen_func_ptr)(self.vm_hooks_ptr, address_handle, token_id_handle, nonce)
     }
 
-    fn managed_is_esdt_limited_transfer(&mut self, token_id_handle: i32) -> i32 {
+    fn managed_is_esdt_limited_transfer(&self, token_id_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_is_esdt_limited_transfer_func_ptr)(self.vm_hooks_ptr, token_id_handle)
     }
 
-    fn managed_is_esdt_paused(&mut self, token_id_handle: i32) -> i32 {
+    fn managed_is_esdt_paused(&self, token_id_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_is_esdt_paused_func_ptr)(self.vm_hooks_ptr, token_id_handle)
     }
 
-    fn managed_buffer_to_hex(&mut self, source_handle: i32, dest_handle: i32) {
+    fn managed_buffer_to_hex(&self, source_handle: i32, dest_handle: i32) {
         (self.c_func_pointers_ptr.managed_buffer_to_hex_func_ptr)(self.vm_hooks_ptr, source_handle, dest_handle)
     }
 
-    fn managed_get_code_metadata(&mut self, address_handle: i32, response_handle: i32) {
+    fn managed_get_code_metadata(&self, address_handle: i32, response_handle: i32) {
         (self.c_func_pointers_ptr.managed_get_code_metadata_func_ptr)(self.vm_hooks_ptr, address_handle, response_handle)
     }
 
-    fn managed_is_builtin_function(&mut self, function_name_handle: i32) -> i32 {
+    fn managed_is_builtin_function(&self, function_name_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_is_builtin_function_func_ptr)(self.vm_hooks_ptr, function_name_handle)
     }
 
-    fn big_float_new_from_parts(&mut self, integral_part: i32, fractional_part: i32, exponent: i32) -> i32 {
+    fn big_float_new_from_parts(&self, integral_part: i32, fractional_part: i32, exponent: i32) -> i32 {
         (self.c_func_pointers_ptr.big_float_new_from_parts_func_ptr)(self.vm_hooks_ptr, integral_part, fractional_part, exponent)
     }
 
-    fn big_float_new_from_frac(&mut self, numerator: i64, denominator: i64) -> i32 {
+    fn big_float_new_from_frac(&self, numerator: i64, denominator: i64) -> i32 {
         (self.c_func_pointers_ptr.big_float_new_from_frac_func_ptr)(self.vm_hooks_ptr, numerator, denominator)
     }
 
-    fn big_float_new_from_sci(&mut self, significand: i64, exponent: i64) -> i32 {
+    fn big_float_new_from_sci(&self, significand: i64, exponent: i64) -> i32 {
         (self.c_func_pointers_ptr.big_float_new_from_sci_func_ptr)(self.vm_hooks_ptr, significand, exponent)
     }
 
-    fn big_float_add(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_float_add(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         (self.c_func_pointers_ptr.big_float_add_func_ptr)(self.vm_hooks_ptr, destination_handle, op1_handle, op2_handle)
     }
 
-    fn big_float_sub(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_float_sub(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         (self.c_func_pointers_ptr.big_float_sub_func_ptr)(self.vm_hooks_ptr, destination_handle, op1_handle, op2_handle)
     }
 
-    fn big_float_mul(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_float_mul(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         (self.c_func_pointers_ptr.big_float_mul_func_ptr)(self.vm_hooks_ptr, destination_handle, op1_handle, op2_handle)
     }
 
-    fn big_float_div(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_float_div(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         (self.c_func_pointers_ptr.big_float_div_func_ptr)(self.vm_hooks_ptr, destination_handle, op1_handle, op2_handle)
     }
 
-    fn big_float_neg(&mut self, destination_handle: i32, op_handle: i32) {
+    fn big_float_neg(&self, destination_handle: i32, op_handle: i32) {
         (self.c_func_pointers_ptr.big_float_neg_func_ptr)(self.vm_hooks_ptr, destination_handle, op_handle)
     }
 
-    fn big_float_clone(&mut self, destination_handle: i32, op_handle: i32) {
+    fn big_float_clone(&self, destination_handle: i32, op_handle: i32) {
         (self.c_func_pointers_ptr.big_float_clone_func_ptr)(self.vm_hooks_ptr, destination_handle, op_handle)
     }
 
-    fn big_float_cmp(&mut self, op1_handle: i32, op2_handle: i32) -> i32 {
+    fn big_float_cmp(&self, op1_handle: i32, op2_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.big_float_cmp_func_ptr)(self.vm_hooks_ptr, op1_handle, op2_handle)
     }
 
-    fn big_float_abs(&mut self, destination_handle: i32, op_handle: i32) {
+    fn big_float_abs(&self, destination_handle: i32, op_handle: i32) {
         (self.c_func_pointers_ptr.big_float_abs_func_ptr)(self.vm_hooks_ptr, destination_handle, op_handle)
     }
 
-    fn big_float_sign(&mut self, op_handle: i32) -> i32 {
+    fn big_float_sign(&self, op_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.big_float_sign_func_ptr)(self.vm_hooks_ptr, op_handle)
     }
 
-    fn big_float_sqrt(&mut self, destination_handle: i32, op_handle: i32) {
+    fn big_float_sqrt(&self, destination_handle: i32, op_handle: i32) {
         (self.c_func_pointers_ptr.big_float_sqrt_func_ptr)(self.vm_hooks_ptr, destination_handle, op_handle)
     }
 
-    fn big_float_pow(&mut self, destination_handle: i32, op_handle: i32, exponent: i32) {
+    fn big_float_pow(&self, destination_handle: i32, op_handle: i32, exponent: i32) {
         (self.c_func_pointers_ptr.big_float_pow_func_ptr)(self.vm_hooks_ptr, destination_handle, op_handle, exponent)
     }
 
-    fn big_float_floor(&mut self, dest_big_int_handle: i32, op_handle: i32) {
+    fn big_float_floor(&self, dest_big_int_handle: i32, op_handle: i32) {
         (self.c_func_pointers_ptr.big_float_floor_func_ptr)(self.vm_hooks_ptr, dest_big_int_handle, op_handle)
     }
 
-    fn big_float_ceil(&mut self, dest_big_int_handle: i32, op_handle: i32) {
+    fn big_float_ceil(&self, dest_big_int_handle: i32, op_handle: i32) {
         (self.c_func_pointers_ptr.big_float_ceil_func_ptr)(self.vm_hooks_ptr, dest_big_int_handle, op_handle)
     }
 
-    fn big_float_truncate(&mut self, dest_big_int_handle: i32, op_handle: i32) {
+    fn big_float_truncate(&self, dest_big_int_handle: i32, op_handle: i32) {
         (self.c_func_pointers_ptr.big_float_truncate_func_ptr)(self.vm_hooks_ptr, dest_big_int_handle, op_handle)
     }
 
-    fn big_float_set_int64(&mut self, destination_handle: i32, value: i64) {
+    fn big_float_set_int64(&self, destination_handle: i32, value: i64) {
         (self.c_func_pointers_ptr.big_float_set_int64_func_ptr)(self.vm_hooks_ptr, destination_handle, value)
     }
 
-    fn big_float_is_int(&mut self, op_handle: i32) -> i32 {
+    fn big_float_is_int(&self, op_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.big_float_is_int_func_ptr)(self.vm_hooks_ptr, op_handle)
     }
 
-    fn big_float_set_big_int(&mut self, destination_handle: i32, big_int_handle: i32) {
+    fn big_float_set_big_int(&self, destination_handle: i32, big_int_handle: i32) {
         (self.c_func_pointers_ptr.big_float_set_big_int_func_ptr)(self.vm_hooks_ptr, destination_handle, big_int_handle)
     }
 
-    fn big_float_get_const_pi(&mut self, destination_handle: i32) {
+    fn big_float_get_const_pi(&self, destination_handle: i32) {
         (self.c_func_pointers_ptr.big_float_get_const_pi_func_ptr)(self.vm_hooks_ptr, destination_handle)
     }
 
-    fn big_float_get_const_e(&mut self, destination_handle: i32) {
+    fn big_float_get_const_e(&self, destination_handle: i32) {
         (self.c_func_pointers_ptr.big_float_get_const_e_func_ptr)(self.vm_hooks_ptr, destination_handle)
     }
 
-    fn big_int_get_unsigned_argument(&mut self, id: i32, destination_handle: i32) {
+    fn big_int_get_unsigned_argument(&self, id: i32, destination_handle: i32) {
         (self.c_func_pointers_ptr.big_int_get_unsigned_argument_func_ptr)(self.vm_hooks_ptr, id, destination_handle)
     }
 
-    fn big_int_get_signed_argument(&mut self, id: i32, destination_handle: i32) {
+    fn big_int_get_signed_argument(&self, id: i32, destination_handle: i32) {
         (self.c_func_pointers_ptr.big_int_get_signed_argument_func_ptr)(self.vm_hooks_ptr, id, destination_handle)
     }
 
-    fn big_int_storage_store_unsigned(&mut self, key_offset: MemPtr, key_length: MemLength, source_handle: i32) -> i32 {
+    fn big_int_storage_store_unsigned(&self, key_offset: MemPtr, key_length: MemLength, source_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.big_int_storage_store_unsigned_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(key_offset), self.convert_mem_length(key_length), source_handle)
     }
 
-    fn big_int_storage_load_unsigned(&mut self, key_offset: MemPtr, key_length: MemLength, destination_handle: i32) -> i32 {
+    fn big_int_storage_load_unsigned(&self, key_offset: MemPtr, key_length: MemLength, destination_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.big_int_storage_load_unsigned_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(key_offset), self.convert_mem_length(key_length), destination_handle)
     }
 
-    fn big_int_get_call_value(&mut self, destination_handle: i32) {
+    fn big_int_get_call_value(&self, destination_handle: i32) {
         (self.c_func_pointers_ptr.big_int_get_call_value_func_ptr)(self.vm_hooks_ptr, destination_handle)
     }
 
-    fn big_int_get_esdt_call_value(&mut self, destination: i32) {
+    fn big_int_get_esdt_call_value(&self, destination: i32) {
         (self.c_func_pointers_ptr.big_int_get_esdt_call_value_func_ptr)(self.vm_hooks_ptr, destination)
     }
 
-    fn big_int_get_esdt_call_value_by_index(&mut self, destination_handle: i32, index: i32) {
+    fn big_int_get_esdt_call_value_by_index(&self, destination_handle: i32, index: i32) {
         (self.c_func_pointers_ptr.big_int_get_esdt_call_value_by_index_func_ptr)(self.vm_hooks_ptr, destination_handle, index)
     }
 
-    fn big_int_get_external_balance(&mut self, address_offset: MemPtr, result: i32) {
+    fn big_int_get_external_balance(&self, address_offset: MemPtr, result: i32) {
         (self.c_func_pointers_ptr.big_int_get_external_balance_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(address_offset), result)
     }
 
-    fn big_int_get_esdt_external_balance(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, result_handle: i32) {
+    fn big_int_get_esdt_external_balance(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, result_handle: i32) {
         (self.c_func_pointers_ptr.big_int_get_esdt_external_balance_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(address_offset), self.convert_mem_ptr(token_id_offset), self.convert_mem_length(token_id_len), nonce, result_handle)
     }
 
-    fn big_int_new(&mut self, small_value: i64) -> i32 {
+    fn big_int_new(&self, small_value: i64) -> i32 {
         (self.c_func_pointers_ptr.big_int_new_func_ptr)(self.vm_hooks_ptr, small_value)
     }
 
-    fn big_int_unsigned_byte_length(&mut self, reference_handle: i32) -> i32 {
+    fn big_int_unsigned_byte_length(&self, reference_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.big_int_unsigned_byte_length_func_ptr)(self.vm_hooks_ptr, reference_handle)
     }
 
-    fn big_int_signed_byte_length(&mut self, reference_handle: i32) -> i32 {
+    fn big_int_signed_byte_length(&self, reference_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.big_int_signed_byte_length_func_ptr)(self.vm_hooks_ptr, reference_handle)
     }
 
-    fn big_int_get_unsigned_bytes(&mut self, reference_handle: i32, byte_offset: MemPtr) -> i32 {
+    fn big_int_get_unsigned_bytes(&self, reference_handle: i32, byte_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.big_int_get_unsigned_bytes_func_ptr)(self.vm_hooks_ptr, reference_handle, self.convert_mem_ptr(byte_offset))
     }
 
-    fn big_int_get_signed_bytes(&mut self, reference_handle: i32, byte_offset: MemPtr) -> i32 {
+    fn big_int_get_signed_bytes(&self, reference_handle: i32, byte_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.big_int_get_signed_bytes_func_ptr)(self.vm_hooks_ptr, reference_handle, self.convert_mem_ptr(byte_offset))
     }
 
-    fn big_int_set_unsigned_bytes(&mut self, destination_handle: i32, byte_offset: MemPtr, byte_length: MemLength) {
+    fn big_int_set_unsigned_bytes(&self, destination_handle: i32, byte_offset: MemPtr, byte_length: MemLength) {
         (self.c_func_pointers_ptr.big_int_set_unsigned_bytes_func_ptr)(self.vm_hooks_ptr, destination_handle, self.convert_mem_ptr(byte_offset), self.convert_mem_length(byte_length))
     }
 
-    fn big_int_set_signed_bytes(&mut self, destination_handle: i32, byte_offset: MemPtr, byte_length: MemLength) {
+    fn big_int_set_signed_bytes(&self, destination_handle: i32, byte_offset: MemPtr, byte_length: MemLength) {
         (self.c_func_pointers_ptr.big_int_set_signed_bytes_func_ptr)(self.vm_hooks_ptr, destination_handle, self.convert_mem_ptr(byte_offset), self.convert_mem_length(byte_length))
     }
 
-    fn big_int_is_int64(&mut self, destination_handle: i32) -> i32 {
+    fn big_int_is_int64(&self, destination_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.big_int_is_int64_func_ptr)(self.vm_hooks_ptr, destination_handle)
     }
 
-    fn big_int_get_int64(&mut self, destination_handle: i32) -> i64 {
+    fn big_int_get_int64(&self, destination_handle: i32) -> i64 {
         (self.c_func_pointers_ptr.big_int_get_int64_func_ptr)(self.vm_hooks_ptr, destination_handle)
     }
 
-    fn big_int_set_int64(&mut self, destination_handle: i32, value: i64) {
+    fn big_int_set_int64(&self, destination_handle: i32, value: i64) {
         (self.c_func_pointers_ptr.big_int_set_int64_func_ptr)(self.vm_hooks_ptr, destination_handle, value)
     }
 
-    fn big_int_add(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_add(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         (self.c_func_pointers_ptr.big_int_add_func_ptr)(self.vm_hooks_ptr, destination_handle, op1_handle, op2_handle)
     }
 
-    fn big_int_sub(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_sub(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         (self.c_func_pointers_ptr.big_int_sub_func_ptr)(self.vm_hooks_ptr, destination_handle, op1_handle, op2_handle)
     }
 
-    fn big_int_mul(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_mul(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         (self.c_func_pointers_ptr.big_int_mul_func_ptr)(self.vm_hooks_ptr, destination_handle, op1_handle, op2_handle)
     }
 
-    fn big_int_tdiv(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_tdiv(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         (self.c_func_pointers_ptr.big_int_tdiv_func_ptr)(self.vm_hooks_ptr, destination_handle, op1_handle, op2_handle)
     }
 
-    fn big_int_tmod(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_tmod(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         (self.c_func_pointers_ptr.big_int_tmod_func_ptr)(self.vm_hooks_ptr, destination_handle, op1_handle, op2_handle)
     }
 
-    fn big_int_ediv(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_ediv(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         (self.c_func_pointers_ptr.big_int_ediv_func_ptr)(self.vm_hooks_ptr, destination_handle, op1_handle, op2_handle)
     }
 
-    fn big_int_emod(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_emod(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         (self.c_func_pointers_ptr.big_int_emod_func_ptr)(self.vm_hooks_ptr, destination_handle, op1_handle, op2_handle)
     }
 
-    fn big_int_sqrt(&mut self, destination_handle: i32, op_handle: i32) {
+    fn big_int_sqrt(&self, destination_handle: i32, op_handle: i32) {
         (self.c_func_pointers_ptr.big_int_sqrt_func_ptr)(self.vm_hooks_ptr, destination_handle, op_handle)
     }
 
-    fn big_int_pow(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_pow(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         (self.c_func_pointers_ptr.big_int_pow_func_ptr)(self.vm_hooks_ptr, destination_handle, op1_handle, op2_handle)
     }
 
-    fn big_int_log2(&mut self, op1_handle: i32) -> i32 {
+    fn big_int_log2(&self, op1_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.big_int_log2_func_ptr)(self.vm_hooks_ptr, op1_handle)
     }
 
-    fn big_int_abs(&mut self, destination_handle: i32, op_handle: i32) {
+    fn big_int_abs(&self, destination_handle: i32, op_handle: i32) {
         (self.c_func_pointers_ptr.big_int_abs_func_ptr)(self.vm_hooks_ptr, destination_handle, op_handle)
     }
 
-    fn big_int_neg(&mut self, destination_handle: i32, op_handle: i32) {
+    fn big_int_neg(&self, destination_handle: i32, op_handle: i32) {
         (self.c_func_pointers_ptr.big_int_neg_func_ptr)(self.vm_hooks_ptr, destination_handle, op_handle)
     }
 
-    fn big_int_sign(&mut self, op_handle: i32) -> i32 {
+    fn big_int_sign(&self, op_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.big_int_sign_func_ptr)(self.vm_hooks_ptr, op_handle)
     }
 
-    fn big_int_cmp(&mut self, op1_handle: i32, op2_handle: i32) -> i32 {
+    fn big_int_cmp(&self, op1_handle: i32, op2_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.big_int_cmp_func_ptr)(self.vm_hooks_ptr, op1_handle, op2_handle)
     }
 
-    fn big_int_not(&mut self, destination_handle: i32, op_handle: i32) {
+    fn big_int_not(&self, destination_handle: i32, op_handle: i32) {
         (self.c_func_pointers_ptr.big_int_not_func_ptr)(self.vm_hooks_ptr, destination_handle, op_handle)
     }
 
-    fn big_int_and(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_and(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         (self.c_func_pointers_ptr.big_int_and_func_ptr)(self.vm_hooks_ptr, destination_handle, op1_handle, op2_handle)
     }
 
-    fn big_int_or(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_or(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         (self.c_func_pointers_ptr.big_int_or_func_ptr)(self.vm_hooks_ptr, destination_handle, op1_handle, op2_handle)
     }
 
-    fn big_int_xor(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_xor(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         (self.c_func_pointers_ptr.big_int_xor_func_ptr)(self.vm_hooks_ptr, destination_handle, op1_handle, op2_handle)
     }
 
-    fn big_int_shr(&mut self, destination_handle: i32, op_handle: i32, bits: i32) {
+    fn big_int_shr(&self, destination_handle: i32, op_handle: i32, bits: i32) {
         (self.c_func_pointers_ptr.big_int_shr_func_ptr)(self.vm_hooks_ptr, destination_handle, op_handle, bits)
     }
 
-    fn big_int_shl(&mut self, destination_handle: i32, op_handle: i32, bits: i32) {
+    fn big_int_shl(&self, destination_handle: i32, op_handle: i32, bits: i32) {
         (self.c_func_pointers_ptr.big_int_shl_func_ptr)(self.vm_hooks_ptr, destination_handle, op_handle, bits)
     }
 
-    fn big_int_finish_unsigned(&mut self, reference_handle: i32) {
+    fn big_int_finish_unsigned(&self, reference_handle: i32) {
         (self.c_func_pointers_ptr.big_int_finish_unsigned_func_ptr)(self.vm_hooks_ptr, reference_handle)
     }
 
-    fn big_int_finish_signed(&mut self, reference_handle: i32) {
+    fn big_int_finish_signed(&self, reference_handle: i32) {
         (self.c_func_pointers_ptr.big_int_finish_signed_func_ptr)(self.vm_hooks_ptr, reference_handle)
     }
 
-    fn big_int_to_string(&mut self, big_int_handle: i32, destination_handle: i32) {
+    fn big_int_to_string(&self, big_int_handle: i32, destination_handle: i32) {
         (self.c_func_pointers_ptr.big_int_to_string_func_ptr)(self.vm_hooks_ptr, big_int_handle, destination_handle)
     }
 
-    fn mbuffer_new(&mut self) -> i32 {
+    fn mbuffer_new(&self) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_new_func_ptr)(self.vm_hooks_ptr)
     }
 
-    fn mbuffer_new_from_bytes(&mut self, data_offset: MemPtr, data_length: MemLength) -> i32 {
+    fn mbuffer_new_from_bytes(&self, data_offset: MemPtr, data_length: MemLength) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_new_from_bytes_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(data_offset), self.convert_mem_length(data_length))
     }
 
-    fn mbuffer_get_length(&mut self, m_buffer_handle: i32) -> i32 {
+    fn mbuffer_get_length(&self, m_buffer_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_get_length_func_ptr)(self.vm_hooks_ptr, m_buffer_handle)
     }
 
-    fn mbuffer_get_bytes(&mut self, m_buffer_handle: i32, result_offset: MemPtr) -> i32 {
+    fn mbuffer_get_bytes(&self, m_buffer_handle: i32, result_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_get_bytes_func_ptr)(self.vm_hooks_ptr, m_buffer_handle, self.convert_mem_ptr(result_offset))
     }
 
-    fn mbuffer_get_byte_slice(&mut self, source_handle: i32, starting_position: i32, slice_length: i32, result_offset: MemPtr) -> i32 {
+    fn mbuffer_get_byte_slice(&self, source_handle: i32, starting_position: i32, slice_length: i32, result_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_get_byte_slice_func_ptr)(self.vm_hooks_ptr, source_handle, starting_position, slice_length, self.convert_mem_ptr(result_offset))
     }
 
-    fn mbuffer_copy_byte_slice(&mut self, source_handle: i32, starting_position: i32, slice_length: i32, destination_handle: i32) -> i32 {
+    fn mbuffer_copy_byte_slice(&self, source_handle: i32, starting_position: i32, slice_length: i32, destination_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_copy_byte_slice_func_ptr)(self.vm_hooks_ptr, source_handle, starting_position, slice_length, destination_handle)
     }
 
-    fn mbuffer_eq(&mut self, m_buffer_handle1: i32, m_buffer_handle2: i32) -> i32 {
+    fn mbuffer_eq(&self, m_buffer_handle1: i32, m_buffer_handle2: i32) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_eq_func_ptr)(self.vm_hooks_ptr, m_buffer_handle1, m_buffer_handle2)
     }
 
-    fn mbuffer_set_bytes(&mut self, m_buffer_handle: i32, data_offset: MemPtr, data_length: MemLength) -> i32 {
+    fn mbuffer_set_bytes(&self, m_buffer_handle: i32, data_offset: MemPtr, data_length: MemLength) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_set_bytes_func_ptr)(self.vm_hooks_ptr, m_buffer_handle, self.convert_mem_ptr(data_offset), self.convert_mem_length(data_length))
     }
 
-    fn mbuffer_set_byte_slice(&mut self, m_buffer_handle: i32, starting_position: i32, data_length: MemLength, data_offset: MemPtr) -> i32 {
+    fn mbuffer_set_byte_slice(&self, m_buffer_handle: i32, starting_position: i32, data_length: MemLength, data_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_set_byte_slice_func_ptr)(self.vm_hooks_ptr, m_buffer_handle, starting_position, self.convert_mem_length(data_length), self.convert_mem_ptr(data_offset))
     }
 
-    fn mbuffer_append(&mut self, accumulator_handle: i32, data_handle: i32) -> i32 {
+    fn mbuffer_append(&self, accumulator_handle: i32, data_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_append_func_ptr)(self.vm_hooks_ptr, accumulator_handle, data_handle)
     }
 
-    fn mbuffer_append_bytes(&mut self, accumulator_handle: i32, data_offset: MemPtr, data_length: MemLength) -> i32 {
+    fn mbuffer_append_bytes(&self, accumulator_handle: i32, data_offset: MemPtr, data_length: MemLength) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_append_bytes_func_ptr)(self.vm_hooks_ptr, accumulator_handle, self.convert_mem_ptr(data_offset), self.convert_mem_length(data_length))
     }
 
-    fn mbuffer_to_big_int_unsigned(&mut self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
+    fn mbuffer_to_big_int_unsigned(&self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_to_big_int_unsigned_func_ptr)(self.vm_hooks_ptr, m_buffer_handle, big_int_handle)
     }
 
-    fn mbuffer_to_big_int_signed(&mut self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
+    fn mbuffer_to_big_int_signed(&self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_to_big_int_signed_func_ptr)(self.vm_hooks_ptr, m_buffer_handle, big_int_handle)
     }
 
-    fn mbuffer_from_big_int_unsigned(&mut self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
+    fn mbuffer_from_big_int_unsigned(&self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_from_big_int_unsigned_func_ptr)(self.vm_hooks_ptr, m_buffer_handle, big_int_handle)
     }
 
-    fn mbuffer_from_big_int_signed(&mut self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
+    fn mbuffer_from_big_int_signed(&self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_from_big_int_signed_func_ptr)(self.vm_hooks_ptr, m_buffer_handle, big_int_handle)
     }
 
-    fn mbuffer_to_big_float(&mut self, m_buffer_handle: i32, big_float_handle: i32) -> i32 {
+    fn mbuffer_to_big_float(&self, m_buffer_handle: i32, big_float_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_to_big_float_func_ptr)(self.vm_hooks_ptr, m_buffer_handle, big_float_handle)
     }
 
-    fn mbuffer_from_big_float(&mut self, m_buffer_handle: i32, big_float_handle: i32) -> i32 {
+    fn mbuffer_from_big_float(&self, m_buffer_handle: i32, big_float_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_from_big_float_func_ptr)(self.vm_hooks_ptr, m_buffer_handle, big_float_handle)
     }
 
-    fn mbuffer_storage_store(&mut self, key_handle: i32, source_handle: i32) -> i32 {
+    fn mbuffer_storage_store(&self, key_handle: i32, source_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_storage_store_func_ptr)(self.vm_hooks_ptr, key_handle, source_handle)
     }
 
-    fn mbuffer_storage_load(&mut self, key_handle: i32, destination_handle: i32) -> i32 {
+    fn mbuffer_storage_load(&self, key_handle: i32, destination_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_storage_load_func_ptr)(self.vm_hooks_ptr, key_handle, destination_handle)
     }
 
-    fn mbuffer_storage_load_from_address(&mut self, address_handle: i32, key_handle: i32, destination_handle: i32) {
+    fn mbuffer_storage_load_from_address(&self, address_handle: i32, key_handle: i32, destination_handle: i32) {
         (self.c_func_pointers_ptr.mbuffer_storage_load_from_address_func_ptr)(self.vm_hooks_ptr, address_handle, key_handle, destination_handle)
     }
 
-    fn mbuffer_get_argument(&mut self, id: i32, destination_handle: i32) -> i32 {
+    fn mbuffer_get_argument(&self, id: i32, destination_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_get_argument_func_ptr)(self.vm_hooks_ptr, id, destination_handle)
     }
 
-    fn mbuffer_finish(&mut self, source_handle: i32) -> i32 {
+    fn mbuffer_finish(&self, source_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_finish_func_ptr)(self.vm_hooks_ptr, source_handle)
     }
 
-    fn mbuffer_set_random(&mut self, destination_handle: i32, length: i32) -> i32 {
+    fn mbuffer_set_random(&self, destination_handle: i32, length: i32) -> i32 {
         (self.c_func_pointers_ptr.mbuffer_set_random_func_ptr)(self.vm_hooks_ptr, destination_handle, length)
     }
 
-    fn managed_map_new(&mut self) -> i32 {
+    fn managed_map_new(&self) -> i32 {
         (self.c_func_pointers_ptr.managed_map_new_func_ptr)(self.vm_hooks_ptr)
     }
 
-    fn managed_map_put(&mut self, m_map_handle: i32, key_handle: i32, value_handle: i32) -> i32 {
+    fn managed_map_put(&self, m_map_handle: i32, key_handle: i32, value_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_map_put_func_ptr)(self.vm_hooks_ptr, m_map_handle, key_handle, value_handle)
     }
 
-    fn managed_map_get(&mut self, m_map_handle: i32, key_handle: i32, out_value_handle: i32) -> i32 {
+    fn managed_map_get(&self, m_map_handle: i32, key_handle: i32, out_value_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_map_get_func_ptr)(self.vm_hooks_ptr, m_map_handle, key_handle, out_value_handle)
     }
 
-    fn managed_map_remove(&mut self, m_map_handle: i32, key_handle: i32, out_value_handle: i32) -> i32 {
+    fn managed_map_remove(&self, m_map_handle: i32, key_handle: i32, out_value_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_map_remove_func_ptr)(self.vm_hooks_ptr, m_map_handle, key_handle, out_value_handle)
     }
 
-    fn managed_map_contains(&mut self, m_map_handle: i32, key_handle: i32) -> i32 {
+    fn managed_map_contains(&self, m_map_handle: i32, key_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_map_contains_func_ptr)(self.vm_hooks_ptr, m_map_handle, key_handle)
     }
 
-    fn small_int_get_unsigned_argument(&mut self, id: i32) -> i64 {
+    fn small_int_get_unsigned_argument(&self, id: i32) -> i64 {
         (self.c_func_pointers_ptr.small_int_get_unsigned_argument_func_ptr)(self.vm_hooks_ptr, id)
     }
 
-    fn small_int_get_signed_argument(&mut self, id: i32) -> i64 {
+    fn small_int_get_signed_argument(&self, id: i32) -> i64 {
         (self.c_func_pointers_ptr.small_int_get_signed_argument_func_ptr)(self.vm_hooks_ptr, id)
     }
 
-    fn small_int_finish_unsigned(&mut self, value: i64) {
+    fn small_int_finish_unsigned(&self, value: i64) {
         (self.c_func_pointers_ptr.small_int_finish_unsigned_func_ptr)(self.vm_hooks_ptr, value)
     }
 
-    fn small_int_finish_signed(&mut self, value: i64) {
+    fn small_int_finish_signed(&self, value: i64) {
         (self.c_func_pointers_ptr.small_int_finish_signed_func_ptr)(self.vm_hooks_ptr, value)
     }
 
-    fn small_int_storage_store_unsigned(&mut self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32 {
+    fn small_int_storage_store_unsigned(&self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32 {
         (self.c_func_pointers_ptr.small_int_storage_store_unsigned_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(key_offset), self.convert_mem_length(key_length), value)
     }
 
-    fn small_int_storage_store_signed(&mut self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32 {
+    fn small_int_storage_store_signed(&self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32 {
         (self.c_func_pointers_ptr.small_int_storage_store_signed_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(key_offset), self.convert_mem_length(key_length), value)
     }
 
-    fn small_int_storage_load_unsigned(&mut self, key_offset: MemPtr, key_length: MemLength) -> i64 {
+    fn small_int_storage_load_unsigned(&self, key_offset: MemPtr, key_length: MemLength) -> i64 {
         (self.c_func_pointers_ptr.small_int_storage_load_unsigned_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(key_offset), self.convert_mem_length(key_length))
     }
 
-    fn small_int_storage_load_signed(&mut self, key_offset: MemPtr, key_length: MemLength) -> i64 {
+    fn small_int_storage_load_signed(&self, key_offset: MemPtr, key_length: MemLength) -> i64 {
         (self.c_func_pointers_ptr.small_int_storage_load_signed_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(key_offset), self.convert_mem_length(key_length))
     }
 
-    fn int64get_argument(&mut self, id: i32) -> i64 {
+    fn int64get_argument(&self, id: i32) -> i64 {
         (self.c_func_pointers_ptr.int64get_argument_func_ptr)(self.vm_hooks_ptr, id)
     }
 
-    fn int64finish(&mut self, value: i64) {
+    fn int64finish(&self, value: i64) {
         (self.c_func_pointers_ptr.int64finish_func_ptr)(self.vm_hooks_ptr, value)
     }
 
-    fn int64storage_store(&mut self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32 {
+    fn int64storage_store(&self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32 {
         (self.c_func_pointers_ptr.int64storage_store_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(key_offset), self.convert_mem_length(key_length), value)
     }
 
-    fn int64storage_load(&mut self, key_offset: MemPtr, key_length: MemLength) -> i64 {
+    fn int64storage_load(&self, key_offset: MemPtr, key_length: MemLength) -> i64 {
         (self.c_func_pointers_ptr.int64storage_load_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(key_offset), self.convert_mem_length(key_length))
     }
 
-    fn sha256(&mut self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32 {
+    fn sha256(&self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.sha256_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(data_offset), self.convert_mem_length(length), self.convert_mem_ptr(result_offset))
     }
 
-    fn managed_sha256(&mut self, input_handle: i32, output_handle: i32) -> i32 {
+    fn managed_sha256(&self, input_handle: i32, output_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_sha256_func_ptr)(self.vm_hooks_ptr, input_handle, output_handle)
     }
 
-    fn keccak256(&mut self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32 {
+    fn keccak256(&self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.keccak256_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(data_offset), self.convert_mem_length(length), self.convert_mem_ptr(result_offset))
     }
 
-    fn managed_keccak256(&mut self, input_handle: i32, output_handle: i32) -> i32 {
+    fn managed_keccak256(&self, input_handle: i32, output_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_keccak256_func_ptr)(self.vm_hooks_ptr, input_handle, output_handle)
     }
 
-    fn ripemd160(&mut self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32 {
+    fn ripemd160(&self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.ripemd160_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(data_offset), self.convert_mem_length(length), self.convert_mem_ptr(result_offset))
     }
 
-    fn managed_ripemd160(&mut self, input_handle: i32, output_handle: i32) -> i32 {
+    fn managed_ripemd160(&self, input_handle: i32, output_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_ripemd160_func_ptr)(self.vm_hooks_ptr, input_handle, output_handle)
     }
 
-    fn verify_bls(&mut self, key_offset: MemPtr, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32 {
+    fn verify_bls(&self, key_offset: MemPtr, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.verify_bls_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(key_offset), self.convert_mem_ptr(message_offset), self.convert_mem_length(message_length), self.convert_mem_ptr(sig_offset))
     }
 
-    fn managed_verify_bls(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
+    fn managed_verify_bls(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_verify_bls_func_ptr)(self.vm_hooks_ptr, key_handle, message_handle, sig_handle)
     }
 
-    fn verify_ed25519(&mut self, key_offset: MemPtr, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32 {
+    fn verify_ed25519(&self, key_offset: MemPtr, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.verify_ed25519_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(key_offset), self.convert_mem_ptr(message_offset), self.convert_mem_length(message_length), self.convert_mem_ptr(sig_offset))
     }
 
-    fn managed_verify_ed25519(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
+    fn managed_verify_ed25519(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_verify_ed25519_func_ptr)(self.vm_hooks_ptr, key_handle, message_handle, sig_handle)
     }
 
-    fn verify_custom_secp256k1(&mut self, key_offset: MemPtr, key_length: MemLength, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr, hash_type: i32) -> i32 {
+    fn verify_custom_secp256k1(&self, key_offset: MemPtr, key_length: MemLength, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr, hash_type: i32) -> i32 {
         (self.c_func_pointers_ptr.verify_custom_secp256k1_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(key_offset), self.convert_mem_length(key_length), self.convert_mem_ptr(message_offset), self.convert_mem_length(message_length), self.convert_mem_ptr(sig_offset), hash_type)
     }
 
-    fn managed_verify_custom_secp256k1(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32, hash_type: i32) -> i32 {
+    fn managed_verify_custom_secp256k1(&self, key_handle: i32, message_handle: i32, sig_handle: i32, hash_type: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_verify_custom_secp256k1_func_ptr)(self.vm_hooks_ptr, key_handle, message_handle, sig_handle, hash_type)
     }
 
-    fn verify_secp256k1(&mut self, key_offset: MemPtr, key_length: MemLength, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32 {
+    fn verify_secp256k1(&self, key_offset: MemPtr, key_length: MemLength, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.verify_secp256k1_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(key_offset), self.convert_mem_length(key_length), self.convert_mem_ptr(message_offset), self.convert_mem_length(message_length), self.convert_mem_ptr(sig_offset))
     }
 
-    fn managed_verify_secp256k1(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
+    fn managed_verify_secp256k1(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_verify_secp256k1_func_ptr)(self.vm_hooks_ptr, key_handle, message_handle, sig_handle)
     }
 
-    fn encode_secp256k1_der_signature(&mut self, r_offset: MemPtr, r_length: MemLength, s_offset: MemPtr, s_length: MemLength, sig_offset: MemPtr) -> i32 {
+    fn encode_secp256k1_der_signature(&self, r_offset: MemPtr, r_length: MemLength, s_offset: MemPtr, s_length: MemLength, sig_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.encode_secp256k1_der_signature_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(r_offset), self.convert_mem_length(r_length), self.convert_mem_ptr(s_offset), self.convert_mem_length(s_length), self.convert_mem_ptr(sig_offset))
     }
 
-    fn managed_encode_secp256k1_der_signature(&mut self, r_handle: i32, s_handle: i32, sig_handle: i32) -> i32 {
+    fn managed_encode_secp256k1_der_signature(&self, r_handle: i32, s_handle: i32, sig_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_encode_secp256k1_der_signature_func_ptr)(self.vm_hooks_ptr, r_handle, s_handle, sig_handle)
     }
 
-    fn add_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, fst_point_xhandle: i32, fst_point_yhandle: i32, snd_point_xhandle: i32, snd_point_yhandle: i32) {
+    fn add_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, fst_point_xhandle: i32, fst_point_yhandle: i32, snd_point_xhandle: i32, snd_point_yhandle: i32) {
         (self.c_func_pointers_ptr.add_ec_func_ptr)(self.vm_hooks_ptr, x_result_handle, y_result_handle, ec_handle, fst_point_xhandle, fst_point_yhandle, snd_point_xhandle, snd_point_yhandle)
     }
 
-    fn double_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32) {
+    fn double_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32) {
         (self.c_func_pointers_ptr.double_ec_func_ptr)(self.vm_hooks_ptr, x_result_handle, y_result_handle, ec_handle, point_xhandle, point_yhandle)
     }
 
-    fn is_on_curve_ec(&mut self, ec_handle: i32, point_xhandle: i32, point_yhandle: i32) -> i32 {
+    fn is_on_curve_ec(&self, ec_handle: i32, point_xhandle: i32, point_yhandle: i32) -> i32 {
         (self.c_func_pointers_ptr.is_on_curve_ec_func_ptr)(self.vm_hooks_ptr, ec_handle, point_xhandle, point_yhandle)
     }
 
-    fn scalar_base_mult_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
+    fn scalar_base_mult_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
         (self.c_func_pointers_ptr.scalar_base_mult_ec_func_ptr)(self.vm_hooks_ptr, x_result_handle, y_result_handle, ec_handle, self.convert_mem_ptr(data_offset), self.convert_mem_length(length))
     }
 
-    fn managed_scalar_base_mult_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
+    fn managed_scalar_base_mult_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_scalar_base_mult_ec_func_ptr)(self.vm_hooks_ptr, x_result_handle, y_result_handle, ec_handle, data_handle)
     }
 
-    fn scalar_mult_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
+    fn scalar_mult_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
         (self.c_func_pointers_ptr.scalar_mult_ec_func_ptr)(self.vm_hooks_ptr, x_result_handle, y_result_handle, ec_handle, point_xhandle, point_yhandle, self.convert_mem_ptr(data_offset), self.convert_mem_length(length))
     }
 
-    fn managed_scalar_mult_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32, data_handle: i32) -> i32 {
+    fn managed_scalar_mult_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32, data_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_scalar_mult_ec_func_ptr)(self.vm_hooks_ptr, x_result_handle, y_result_handle, ec_handle, point_xhandle, point_yhandle, data_handle)
     }
 
-    fn marshal_ec(&mut self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32 {
+    fn marshal_ec(&self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.marshal_ec_func_ptr)(self.vm_hooks_ptr, x_pair_handle, y_pair_handle, ec_handle, self.convert_mem_ptr(result_offset))
     }
 
-    fn managed_marshal_ec(&mut self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
+    fn managed_marshal_ec(&self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_marshal_ec_func_ptr)(self.vm_hooks_ptr, x_pair_handle, y_pair_handle, ec_handle, result_handle)
     }
 
-    fn marshal_compressed_ec(&mut self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32 {
+    fn marshal_compressed_ec(&self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.marshal_compressed_ec_func_ptr)(self.vm_hooks_ptr, x_pair_handle, y_pair_handle, ec_handle, self.convert_mem_ptr(result_offset))
     }
 
-    fn managed_marshal_compressed_ec(&mut self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
+    fn managed_marshal_compressed_ec(&self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_marshal_compressed_ec_func_ptr)(self.vm_hooks_ptr, x_pair_handle, y_pair_handle, ec_handle, result_handle)
     }
 
-    fn unmarshal_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
+    fn unmarshal_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
         (self.c_func_pointers_ptr.unmarshal_ec_func_ptr)(self.vm_hooks_ptr, x_result_handle, y_result_handle, ec_handle, self.convert_mem_ptr(data_offset), self.convert_mem_length(length))
     }
 
-    fn managed_unmarshal_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
+    fn managed_unmarshal_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_unmarshal_ec_func_ptr)(self.vm_hooks_ptr, x_result_handle, y_result_handle, ec_handle, data_handle)
     }
 
-    fn unmarshal_compressed_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
+    fn unmarshal_compressed_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
         (self.c_func_pointers_ptr.unmarshal_compressed_ec_func_ptr)(self.vm_hooks_ptr, x_result_handle, y_result_handle, ec_handle, self.convert_mem_ptr(data_offset), self.convert_mem_length(length))
     }
 
-    fn managed_unmarshal_compressed_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
+    fn managed_unmarshal_compressed_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_unmarshal_compressed_ec_func_ptr)(self.vm_hooks_ptr, x_result_handle, y_result_handle, ec_handle, data_handle)
     }
 
-    fn generate_key_ec(&mut self, x_pub_key_handle: i32, y_pub_key_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32 {
+    fn generate_key_ec(&self, x_pub_key_handle: i32, y_pub_key_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32 {
         (self.c_func_pointers_ptr.generate_key_ec_func_ptr)(self.vm_hooks_ptr, x_pub_key_handle, y_pub_key_handle, ec_handle, self.convert_mem_ptr(result_offset))
     }
 
-    fn managed_generate_key_ec(&mut self, x_pub_key_handle: i32, y_pub_key_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
+    fn managed_generate_key_ec(&self, x_pub_key_handle: i32, y_pub_key_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_generate_key_ec_func_ptr)(self.vm_hooks_ptr, x_pub_key_handle, y_pub_key_handle, ec_handle, result_handle)
     }
 
-    fn create_ec(&mut self, data_offset: MemPtr, data_length: MemLength) -> i32 {
+    fn create_ec(&self, data_offset: MemPtr, data_length: MemLength) -> i32 {
         (self.c_func_pointers_ptr.create_ec_func_ptr)(self.vm_hooks_ptr, self.convert_mem_ptr(data_offset), self.convert_mem_length(data_length))
     }
 
-    fn managed_create_ec(&mut self, data_handle: i32) -> i32 {
+    fn managed_create_ec(&self, data_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_create_ec_func_ptr)(self.vm_hooks_ptr, data_handle)
     }
 
-    fn get_curve_length_ec(&mut self, ec_handle: i32) -> i32 {
+    fn get_curve_length_ec(&self, ec_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.get_curve_length_ec_func_ptr)(self.vm_hooks_ptr, ec_handle)
     }
 
-    fn get_priv_key_byte_length_ec(&mut self, ec_handle: i32) -> i32 {
+    fn get_priv_key_byte_length_ec(&self, ec_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.get_priv_key_byte_length_ec_func_ptr)(self.vm_hooks_ptr, ec_handle)
     }
 
-    fn elliptic_curve_get_values(&mut self, ec_handle: i32, field_order_handle: i32, base_point_order_handle: i32, eq_constant_handle: i32, x_base_point_handle: i32, y_base_point_handle: i32) -> i32 {
+    fn elliptic_curve_get_values(&self, ec_handle: i32, field_order_handle: i32, base_point_order_handle: i32, eq_constant_handle: i32, x_base_point_handle: i32, y_base_point_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.elliptic_curve_get_values_func_ptr)(self.vm_hooks_ptr, ec_handle, field_order_handle, base_point_order_handle, eq_constant_handle, x_base_point_handle, y_base_point_handle)
     }
 
-    fn managed_verify_secp256r1(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
+    fn managed_verify_secp256r1(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_verify_secp256r1_func_ptr)(self.vm_hooks_ptr, key_handle, message_handle, sig_handle)
     }
 
-    fn managed_verify_blssignature_share(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
+    fn managed_verify_blssignature_share(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_verify_blssignature_share_func_ptr)(self.vm_hooks_ptr, key_handle, message_handle, sig_handle)
     }
 
-    fn managed_verify_blsaggregated_signature(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
+    fn managed_verify_blsaggregated_signature(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
         (self.c_func_pointers_ptr.managed_verify_blsaggregated_signature_func_ptr)(self.vm_hooks_ptr, key_handle, message_handle, sig_handle)
     }
 }

--- a/vm-executor-wasmer/src/new_traits/wasmer_prod_executor.rs
+++ b/vm-executor-wasmer/src/new_traits/wasmer_prod_executor.rs
@@ -4,7 +4,6 @@ use multiversx_chain_vm_executor::{
     VMHooksLegacy,
 };
 use std::{
-    cell::RefCell,
     fmt,
     rc::Rc,
     sync::{Arc, Mutex},
@@ -44,7 +43,7 @@ impl WasmerProdExecutor {
             let vm_hooks = self.runtime_ref.vm_hooks(instance_state);
 
             WasmerInstance::try_new_instance(
-                Rc::new(RefCell::new(vm_hooks)),
+                Rc::new(vm_hooks),
                 self.runtime_ref.opcode_cost(),
                 wasm_bytes,
                 compilation_options,

--- a/vm-executor-wasmer/src/wasmer_executor.rs
+++ b/vm-executor-wasmer/src/wasmer_executor.rs
@@ -18,21 +18,21 @@ pub fn force_sighandler_reinstall() {
 }
 
 pub struct WasmerExecutorData {
-    vm_hooks: Rc<RefCell<Box<dyn VMHooksLegacy>>>,
+    vm_hooks: Rc<Box<dyn VMHooksLegacy>>,
     opcode_cost: Arc<Mutex<OpcodeCost>>,
 }
 
 impl WasmerExecutorData {
     pub fn new(vm_hooks: Box<dyn VMHooksLegacy>) -> Self {
         Self {
-            vm_hooks: Rc::new(RefCell::new(vm_hooks)),
+            vm_hooks: Rc::new(vm_hooks),
             opcode_cost: Arc::new(Mutex::new(OpcodeCost::default())),
         }
     }
 
     fn set_vm_hooks_ptr(&mut self, vm_hooks_ptr: *mut c_void) -> Result<(), ExecutorError> {
         if let Some(vm_hooks) = Rc::get_mut(&mut self.vm_hooks) {
-            vm_hooks.borrow_mut().set_vm_hooks_ptr(vm_hooks_ptr);
+            vm_hooks.set_vm_hooks_ptr(vm_hooks_ptr);
             Ok(())
         } else {
             Err(Box::new(ServiceError::new(

--- a/vm-executor-wasmer/src/wasmer_imports.rs
+++ b/vm-executor-wasmer/src/wasmer_imports.rs
@@ -12,1312 +12,1312 @@ use crate::wasmer_vm_hooks::VMHooksWrapper;
 
 #[rustfmt::skip]
 fn wasmer_import_get_gas_left(env: &VMHooksWrapper) -> i64 {
-    env.with_vm_hooks(|vh| vh.get_gas_left())
+    env.vm_hooks.get_gas_left()
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_sc_address(env: &VMHooksWrapper, result_offset: i32) {
-    env.with_vm_hooks(|vh| vh.get_sc_address(env.convert_mem_ptr(result_offset)))
+    env.vm_hooks.get_sc_address(env.convert_mem_ptr(result_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_owner_address(env: &VMHooksWrapper, result_offset: i32) {
-    env.with_vm_hooks(|vh| vh.get_owner_address(env.convert_mem_ptr(result_offset)))
+    env.vm_hooks.get_owner_address(env.convert_mem_ptr(result_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_shard_of_address(env: &VMHooksWrapper, address_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_shard_of_address(env.convert_mem_ptr(address_offset)))
+    env.vm_hooks.get_shard_of_address(env.convert_mem_ptr(address_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_is_smart_contract(env: &VMHooksWrapper, address_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.is_smart_contract(env.convert_mem_ptr(address_offset)))
+    env.vm_hooks.is_smart_contract(env.convert_mem_ptr(address_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_signal_error(env: &VMHooksWrapper, message_offset: i32, message_length: i32) {
-    env.with_vm_hooks(|vh| vh.signal_error(env.convert_mem_ptr(message_offset), env.convert_mem_length(message_length)))
+    env.vm_hooks.signal_error(env.convert_mem_ptr(message_offset), env.convert_mem_length(message_length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_external_balance(env: &VMHooksWrapper, address_offset: i32, result_offset: i32) {
-    env.with_vm_hooks(|vh| vh.get_external_balance(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(result_offset)))
+    env.vm_hooks.get_external_balance(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(result_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_block_hash(env: &VMHooksWrapper, nonce: i64, result_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_block_hash(nonce, env.convert_mem_ptr(result_offset)))
+    env.vm_hooks.get_block_hash(nonce, env.convert_mem_ptr(result_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_esdt_balance(env: &VMHooksWrapper, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64, result_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_esdt_balance(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), nonce, env.convert_mem_ptr(result_offset)))
+    env.vm_hooks.get_esdt_balance(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), nonce, env.convert_mem_ptr(result_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_esdt_nft_name_length(env: &VMHooksWrapper, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_esdt_nft_name_length(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), nonce))
+    env.vm_hooks.get_esdt_nft_name_length(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), nonce)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_esdt_nft_attribute_length(env: &VMHooksWrapper, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_esdt_nft_attribute_length(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), nonce))
+    env.vm_hooks.get_esdt_nft_attribute_length(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), nonce)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_esdt_nft_uri_length(env: &VMHooksWrapper, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_esdt_nft_uri_length(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), nonce))
+    env.vm_hooks.get_esdt_nft_uri_length(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), nonce)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_esdt_token_data(env: &VMHooksWrapper, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64, value_handle: i32, properties_offset: i32, hash_offset: i32, name_offset: i32, attributes_offset: i32, creator_offset: i32, royalties_handle: i32, uris_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_esdt_token_data(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), nonce, value_handle, env.convert_mem_ptr(properties_offset), env.convert_mem_ptr(hash_offset), env.convert_mem_ptr(name_offset), env.convert_mem_ptr(attributes_offset), env.convert_mem_ptr(creator_offset), royalties_handle, env.convert_mem_ptr(uris_offset)))
+    env.vm_hooks.get_esdt_token_data(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), nonce, value_handle, env.convert_mem_ptr(properties_offset), env.convert_mem_ptr(hash_offset), env.convert_mem_ptr(name_offset), env.convert_mem_ptr(attributes_offset), env.convert_mem_ptr(creator_offset), royalties_handle, env.convert_mem_ptr(uris_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_esdt_local_roles(env: &VMHooksWrapper, token_id_handle: i32) -> i64 {
-    env.with_vm_hooks(|vh| vh.get_esdt_local_roles(token_id_handle))
+    env.vm_hooks.get_esdt_local_roles(token_id_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_validate_token_identifier(env: &VMHooksWrapper, token_id_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.validate_token_identifier(token_id_handle))
+    env.vm_hooks.validate_token_identifier(token_id_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_transfer_value(env: &VMHooksWrapper, dest_offset: i32, value_offset: i32, data_offset: i32, length: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.transfer_value(env.convert_mem_ptr(dest_offset), env.convert_mem_ptr(value_offset), env.convert_mem_ptr(data_offset), env.convert_mem_length(length)))
+    env.vm_hooks.transfer_value(env.convert_mem_ptr(dest_offset), env.convert_mem_ptr(value_offset), env.convert_mem_ptr(data_offset), env.convert_mem_length(length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_transfer_value_execute(env: &VMHooksWrapper, dest_offset: i32, value_offset: i32, gas_limit: i64, function_offset: i32, function_length: i32, num_arguments: i32, arguments_length_offset: i32, data_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.transfer_value_execute(env.convert_mem_ptr(dest_offset), env.convert_mem_ptr(value_offset), gas_limit, env.convert_mem_ptr(function_offset), env.convert_mem_length(function_length), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset)))
+    env.vm_hooks.transfer_value_execute(env.convert_mem_ptr(dest_offset), env.convert_mem_ptr(value_offset), gas_limit, env.convert_mem_ptr(function_offset), env.convert_mem_length(function_length), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_transfer_esdt_execute(env: &VMHooksWrapper, dest_offset: i32, token_id_offset: i32, token_id_len: i32, value_offset: i32, gas_limit: i64, function_offset: i32, function_length: i32, num_arguments: i32, arguments_length_offset: i32, data_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.transfer_esdt_execute(env.convert_mem_ptr(dest_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), env.convert_mem_ptr(value_offset), gas_limit, env.convert_mem_ptr(function_offset), env.convert_mem_length(function_length), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset)))
+    env.vm_hooks.transfer_esdt_execute(env.convert_mem_ptr(dest_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), env.convert_mem_ptr(value_offset), gas_limit, env.convert_mem_ptr(function_offset), env.convert_mem_length(function_length), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_transfer_esdt_nft_execute(env: &VMHooksWrapper, dest_offset: i32, token_id_offset: i32, token_id_len: i32, value_offset: i32, nonce: i64, gas_limit: i64, function_offset: i32, function_length: i32, num_arguments: i32, arguments_length_offset: i32, data_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.transfer_esdt_nft_execute(env.convert_mem_ptr(dest_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), env.convert_mem_ptr(value_offset), nonce, gas_limit, env.convert_mem_ptr(function_offset), env.convert_mem_length(function_length), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset)))
+    env.vm_hooks.transfer_esdt_nft_execute(env.convert_mem_ptr(dest_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), env.convert_mem_ptr(value_offset), nonce, gas_limit, env.convert_mem_ptr(function_offset), env.convert_mem_length(function_length), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_multi_transfer_esdt_nft_execute(env: &VMHooksWrapper, dest_offset: i32, num_token_transfers: i32, token_transfers_args_length_offset: i32, token_transfer_data_offset: i32, gas_limit: i64, function_offset: i32, function_length: i32, num_arguments: i32, arguments_length_offset: i32, data_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.multi_transfer_esdt_nft_execute(env.convert_mem_ptr(dest_offset), num_token_transfers, env.convert_mem_ptr(token_transfers_args_length_offset), env.convert_mem_ptr(token_transfer_data_offset), gas_limit, env.convert_mem_ptr(function_offset), env.convert_mem_length(function_length), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset)))
+    env.vm_hooks.multi_transfer_esdt_nft_execute(env.convert_mem_ptr(dest_offset), num_token_transfers, env.convert_mem_ptr(token_transfers_args_length_offset), env.convert_mem_ptr(token_transfer_data_offset), gas_limit, env.convert_mem_ptr(function_offset), env.convert_mem_length(function_length), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_create_async_call(env: &VMHooksWrapper, dest_offset: i32, value_offset: i32, data_offset: i32, data_length: i32, success_offset: i32, success_length: i32, error_offset: i32, error_length: i32, gas: i64, extra_gas_for_callback: i64) -> i32 {
-    env.with_vm_hooks(|vh| vh.create_async_call(env.convert_mem_ptr(dest_offset), env.convert_mem_ptr(value_offset), env.convert_mem_ptr(data_offset), env.convert_mem_length(data_length), env.convert_mem_ptr(success_offset), env.convert_mem_length(success_length), env.convert_mem_ptr(error_offset), env.convert_mem_length(error_length), gas, extra_gas_for_callback))
+    env.vm_hooks.create_async_call(env.convert_mem_ptr(dest_offset), env.convert_mem_ptr(value_offset), env.convert_mem_ptr(data_offset), env.convert_mem_length(data_length), env.convert_mem_ptr(success_offset), env.convert_mem_length(success_length), env.convert_mem_ptr(error_offset), env.convert_mem_length(error_length), gas, extra_gas_for_callback)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_set_async_context_callback(env: &VMHooksWrapper, callback: i32, callback_length: i32, data: i32, data_length: i32, gas: i64) -> i32 {
-    env.with_vm_hooks(|vh| vh.set_async_context_callback(env.convert_mem_ptr(callback), env.convert_mem_length(callback_length), env.convert_mem_ptr(data), env.convert_mem_length(data_length), gas))
+    env.vm_hooks.set_async_context_callback(env.convert_mem_ptr(callback), env.convert_mem_length(callback_length), env.convert_mem_ptr(data), env.convert_mem_length(data_length), gas)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_upgrade_contract(env: &VMHooksWrapper, dest_offset: i32, gas_limit: i64, value_offset: i32, code_offset: i32, code_metadata_offset: i32, length: i32, num_arguments: i32, arguments_length_offset: i32, data_offset: i32) {
-    env.with_vm_hooks(|vh| vh.upgrade_contract(env.convert_mem_ptr(dest_offset), gas_limit, env.convert_mem_ptr(value_offset), env.convert_mem_ptr(code_offset), env.convert_mem_ptr(code_metadata_offset), env.convert_mem_length(length), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset)))
+    env.vm_hooks.upgrade_contract(env.convert_mem_ptr(dest_offset), gas_limit, env.convert_mem_ptr(value_offset), env.convert_mem_ptr(code_offset), env.convert_mem_ptr(code_metadata_offset), env.convert_mem_length(length), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_upgrade_from_source_contract(env: &VMHooksWrapper, dest_offset: i32, gas_limit: i64, value_offset: i32, source_contract_address_offset: i32, code_metadata_offset: i32, num_arguments: i32, arguments_length_offset: i32, data_offset: i32) {
-    env.with_vm_hooks(|vh| vh.upgrade_from_source_contract(env.convert_mem_ptr(dest_offset), gas_limit, env.convert_mem_ptr(value_offset), env.convert_mem_ptr(source_contract_address_offset), env.convert_mem_ptr(code_metadata_offset), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset)))
+    env.vm_hooks.upgrade_from_source_contract(env.convert_mem_ptr(dest_offset), gas_limit, env.convert_mem_ptr(value_offset), env.convert_mem_ptr(source_contract_address_offset), env.convert_mem_ptr(code_metadata_offset), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_delete_contract(env: &VMHooksWrapper, dest_offset: i32, gas_limit: i64, num_arguments: i32, arguments_length_offset: i32, data_offset: i32) {
-    env.with_vm_hooks(|vh| vh.delete_contract(env.convert_mem_ptr(dest_offset), gas_limit, num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset)))
+    env.vm_hooks.delete_contract(env.convert_mem_ptr(dest_offset), gas_limit, num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_async_call(env: &VMHooksWrapper, dest_offset: i32, value_offset: i32, data_offset: i32, length: i32) {
-    env.with_vm_hooks(|vh| vh.async_call(env.convert_mem_ptr(dest_offset), env.convert_mem_ptr(value_offset), env.convert_mem_ptr(data_offset), env.convert_mem_length(length)))
+    env.vm_hooks.async_call(env.convert_mem_ptr(dest_offset), env.convert_mem_ptr(value_offset), env.convert_mem_ptr(data_offset), env.convert_mem_length(length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_argument_length(env: &VMHooksWrapper, id: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_argument_length(id))
+    env.vm_hooks.get_argument_length(id)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_argument(env: &VMHooksWrapper, id: i32, arg_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_argument(id, env.convert_mem_ptr(arg_offset)))
+    env.vm_hooks.get_argument(id, env.convert_mem_ptr(arg_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_function(env: &VMHooksWrapper, function_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_function(env.convert_mem_ptr(function_offset)))
+    env.vm_hooks.get_function(env.convert_mem_ptr(function_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_num_arguments(env: &VMHooksWrapper) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_num_arguments())
+    env.vm_hooks.get_num_arguments()
 }
 
 #[rustfmt::skip]
 fn wasmer_import_storage_store(env: &VMHooksWrapper, key_offset: i32, key_length: i32, data_offset: i32, data_length: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.storage_store(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), env.convert_mem_ptr(data_offset), env.convert_mem_length(data_length)))
+    env.vm_hooks.storage_store(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), env.convert_mem_ptr(data_offset), env.convert_mem_length(data_length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_storage_load_length(env: &VMHooksWrapper, key_offset: i32, key_length: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.storage_load_length(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length)))
+    env.vm_hooks.storage_load_length(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_storage_load_from_address(env: &VMHooksWrapper, address_offset: i32, key_offset: i32, key_length: i32, data_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.storage_load_from_address(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), env.convert_mem_ptr(data_offset)))
+    env.vm_hooks.storage_load_from_address(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), env.convert_mem_ptr(data_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_storage_load(env: &VMHooksWrapper, key_offset: i32, key_length: i32, data_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.storage_load(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), env.convert_mem_ptr(data_offset)))
+    env.vm_hooks.storage_load(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), env.convert_mem_ptr(data_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_set_storage_lock(env: &VMHooksWrapper, key_offset: i32, key_length: i32, lock_timestamp: i64) -> i32 {
-    env.with_vm_hooks(|vh| vh.set_storage_lock(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), lock_timestamp))
+    env.vm_hooks.set_storage_lock(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), lock_timestamp)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_storage_lock(env: &VMHooksWrapper, key_offset: i32, key_length: i32) -> i64 {
-    env.with_vm_hooks(|vh| vh.get_storage_lock(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length)))
+    env.vm_hooks.get_storage_lock(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_is_storage_locked(env: &VMHooksWrapper, key_offset: i32, key_length: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.is_storage_locked(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length)))
+    env.vm_hooks.is_storage_locked(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_clear_storage_lock(env: &VMHooksWrapper, key_offset: i32, key_length: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.clear_storage_lock(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length)))
+    env.vm_hooks.clear_storage_lock(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_caller(env: &VMHooksWrapper, result_offset: i32) {
-    env.with_vm_hooks(|vh| vh.get_caller(env.convert_mem_ptr(result_offset)))
+    env.vm_hooks.get_caller(env.convert_mem_ptr(result_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_check_no_payment(env: &VMHooksWrapper) {
-    env.with_vm_hooks(|vh| vh.check_no_payment())
+    env.vm_hooks.check_no_payment()
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_call_value(env: &VMHooksWrapper, result_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_call_value(env.convert_mem_ptr(result_offset)))
+    env.vm_hooks.get_call_value(env.convert_mem_ptr(result_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_esdt_value(env: &VMHooksWrapper, result_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_esdt_value(env.convert_mem_ptr(result_offset)))
+    env.vm_hooks.get_esdt_value(env.convert_mem_ptr(result_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_esdt_value_by_index(env: &VMHooksWrapper, result_offset: i32, index: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_esdt_value_by_index(env.convert_mem_ptr(result_offset), index))
+    env.vm_hooks.get_esdt_value_by_index(env.convert_mem_ptr(result_offset), index)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_esdt_token_name(env: &VMHooksWrapper, result_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_esdt_token_name(env.convert_mem_ptr(result_offset)))
+    env.vm_hooks.get_esdt_token_name(env.convert_mem_ptr(result_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_esdt_token_name_by_index(env: &VMHooksWrapper, result_offset: i32, index: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_esdt_token_name_by_index(env.convert_mem_ptr(result_offset), index))
+    env.vm_hooks.get_esdt_token_name_by_index(env.convert_mem_ptr(result_offset), index)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_esdt_token_nonce(env: &VMHooksWrapper) -> i64 {
-    env.with_vm_hooks(|vh| vh.get_esdt_token_nonce())
+    env.vm_hooks.get_esdt_token_nonce()
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_esdt_token_nonce_by_index(env: &VMHooksWrapper, index: i32) -> i64 {
-    env.with_vm_hooks(|vh| vh.get_esdt_token_nonce_by_index(index))
+    env.vm_hooks.get_esdt_token_nonce_by_index(index)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_current_esdt_nft_nonce(env: &VMHooksWrapper, address_offset: i32, token_id_offset: i32, token_id_len: i32) -> i64 {
-    env.with_vm_hooks(|vh| vh.get_current_esdt_nft_nonce(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len)))
+    env.vm_hooks.get_current_esdt_nft_nonce(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_esdt_token_type(env: &VMHooksWrapper) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_esdt_token_type())
+    env.vm_hooks.get_esdt_token_type()
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_esdt_token_type_by_index(env: &VMHooksWrapper, index: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_esdt_token_type_by_index(index))
+    env.vm_hooks.get_esdt_token_type_by_index(index)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_num_esdt_transfers(env: &VMHooksWrapper) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_num_esdt_transfers())
+    env.vm_hooks.get_num_esdt_transfers()
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_call_value_token_name(env: &VMHooksWrapper, call_value_offset: i32, token_name_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_call_value_token_name(env.convert_mem_ptr(call_value_offset), env.convert_mem_ptr(token_name_offset)))
+    env.vm_hooks.get_call_value_token_name(env.convert_mem_ptr(call_value_offset), env.convert_mem_ptr(token_name_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_call_value_token_name_by_index(env: &VMHooksWrapper, call_value_offset: i32, token_name_offset: i32, index: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_call_value_token_name_by_index(env.convert_mem_ptr(call_value_offset), env.convert_mem_ptr(token_name_offset), index))
+    env.vm_hooks.get_call_value_token_name_by_index(env.convert_mem_ptr(call_value_offset), env.convert_mem_ptr(token_name_offset), index)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_is_reserved_function_name(env: &VMHooksWrapper, name_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.is_reserved_function_name(name_handle))
+    env.vm_hooks.is_reserved_function_name(name_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_write_log(env: &VMHooksWrapper, data_pointer: i32, data_length: i32, topic_ptr: i32, num_topics: i32) {
-    env.with_vm_hooks(|vh| vh.write_log(env.convert_mem_ptr(data_pointer), env.convert_mem_length(data_length), env.convert_mem_ptr(topic_ptr), num_topics))
+    env.vm_hooks.write_log(env.convert_mem_ptr(data_pointer), env.convert_mem_length(data_length), env.convert_mem_ptr(topic_ptr), num_topics)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_write_event_log(env: &VMHooksWrapper, num_topics: i32, topic_lengths_offset: i32, topic_offset: i32, data_offset: i32, data_length: i32) {
-    env.with_vm_hooks(|vh| vh.write_event_log(num_topics, env.convert_mem_ptr(topic_lengths_offset), env.convert_mem_ptr(topic_offset), env.convert_mem_ptr(data_offset), env.convert_mem_length(data_length)))
+    env.vm_hooks.write_event_log(num_topics, env.convert_mem_ptr(topic_lengths_offset), env.convert_mem_ptr(topic_offset), env.convert_mem_ptr(data_offset), env.convert_mem_length(data_length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_block_timestamp(env: &VMHooksWrapper) -> i64 {
-    env.with_vm_hooks(|vh| vh.get_block_timestamp())
+    env.vm_hooks.get_block_timestamp()
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_block_nonce(env: &VMHooksWrapper) -> i64 {
-    env.with_vm_hooks(|vh| vh.get_block_nonce())
+    env.vm_hooks.get_block_nonce()
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_block_round(env: &VMHooksWrapper) -> i64 {
-    env.with_vm_hooks(|vh| vh.get_block_round())
+    env.vm_hooks.get_block_round()
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_block_epoch(env: &VMHooksWrapper) -> i64 {
-    env.with_vm_hooks(|vh| vh.get_block_epoch())
+    env.vm_hooks.get_block_epoch()
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_block_random_seed(env: &VMHooksWrapper, pointer: i32) {
-    env.with_vm_hooks(|vh| vh.get_block_random_seed(env.convert_mem_ptr(pointer)))
+    env.vm_hooks.get_block_random_seed(env.convert_mem_ptr(pointer))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_state_root_hash(env: &VMHooksWrapper, pointer: i32) {
-    env.with_vm_hooks(|vh| vh.get_state_root_hash(env.convert_mem_ptr(pointer)))
+    env.vm_hooks.get_state_root_hash(env.convert_mem_ptr(pointer))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_prev_block_timestamp(env: &VMHooksWrapper) -> i64 {
-    env.with_vm_hooks(|vh| vh.get_prev_block_timestamp())
+    env.vm_hooks.get_prev_block_timestamp()
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_prev_block_nonce(env: &VMHooksWrapper) -> i64 {
-    env.with_vm_hooks(|vh| vh.get_prev_block_nonce())
+    env.vm_hooks.get_prev_block_nonce()
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_prev_block_round(env: &VMHooksWrapper) -> i64 {
-    env.with_vm_hooks(|vh| vh.get_prev_block_round())
+    env.vm_hooks.get_prev_block_round()
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_prev_block_epoch(env: &VMHooksWrapper) -> i64 {
-    env.with_vm_hooks(|vh| vh.get_prev_block_epoch())
+    env.vm_hooks.get_prev_block_epoch()
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_prev_block_random_seed(env: &VMHooksWrapper, pointer: i32) {
-    env.with_vm_hooks(|vh| vh.get_prev_block_random_seed(env.convert_mem_ptr(pointer)))
+    env.vm_hooks.get_prev_block_random_seed(env.convert_mem_ptr(pointer))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_finish(env: &VMHooksWrapper, pointer: i32, length: i32) {
-    env.with_vm_hooks(|vh| vh.finish(env.convert_mem_ptr(pointer), env.convert_mem_length(length)))
+    env.vm_hooks.finish(env.convert_mem_ptr(pointer), env.convert_mem_length(length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_execute_on_same_context(env: &VMHooksWrapper, gas_limit: i64, address_offset: i32, value_offset: i32, function_offset: i32, function_length: i32, num_arguments: i32, arguments_length_offset: i32, data_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.execute_on_same_context(gas_limit, env.convert_mem_ptr(address_offset), env.convert_mem_ptr(value_offset), env.convert_mem_ptr(function_offset), env.convert_mem_length(function_length), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset)))
+    env.vm_hooks.execute_on_same_context(gas_limit, env.convert_mem_ptr(address_offset), env.convert_mem_ptr(value_offset), env.convert_mem_ptr(function_offset), env.convert_mem_length(function_length), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_execute_on_dest_context(env: &VMHooksWrapper, gas_limit: i64, address_offset: i32, value_offset: i32, function_offset: i32, function_length: i32, num_arguments: i32, arguments_length_offset: i32, data_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.execute_on_dest_context(gas_limit, env.convert_mem_ptr(address_offset), env.convert_mem_ptr(value_offset), env.convert_mem_ptr(function_offset), env.convert_mem_length(function_length), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset)))
+    env.vm_hooks.execute_on_dest_context(gas_limit, env.convert_mem_ptr(address_offset), env.convert_mem_ptr(value_offset), env.convert_mem_ptr(function_offset), env.convert_mem_length(function_length), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_execute_read_only(env: &VMHooksWrapper, gas_limit: i64, address_offset: i32, function_offset: i32, function_length: i32, num_arguments: i32, arguments_length_offset: i32, data_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.execute_read_only(gas_limit, env.convert_mem_ptr(address_offset), env.convert_mem_ptr(function_offset), env.convert_mem_length(function_length), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset)))
+    env.vm_hooks.execute_read_only(gas_limit, env.convert_mem_ptr(address_offset), env.convert_mem_ptr(function_offset), env.convert_mem_length(function_length), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_create_contract(env: &VMHooksWrapper, gas_limit: i64, value_offset: i32, code_offset: i32, code_metadata_offset: i32, length: i32, result_offset: i32, num_arguments: i32, arguments_length_offset: i32, data_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.create_contract(gas_limit, env.convert_mem_ptr(value_offset), env.convert_mem_ptr(code_offset), env.convert_mem_ptr(code_metadata_offset), env.convert_mem_length(length), env.convert_mem_ptr(result_offset), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset)))
+    env.vm_hooks.create_contract(gas_limit, env.convert_mem_ptr(value_offset), env.convert_mem_ptr(code_offset), env.convert_mem_ptr(code_metadata_offset), env.convert_mem_length(length), env.convert_mem_ptr(result_offset), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_deploy_from_source_contract(env: &VMHooksWrapper, gas_limit: i64, value_offset: i32, source_contract_address_offset: i32, code_metadata_offset: i32, result_address_offset: i32, num_arguments: i32, arguments_length_offset: i32, data_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.deploy_from_source_contract(gas_limit, env.convert_mem_ptr(value_offset), env.convert_mem_ptr(source_contract_address_offset), env.convert_mem_ptr(code_metadata_offset), env.convert_mem_ptr(result_address_offset), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset)))
+    env.vm_hooks.deploy_from_source_contract(gas_limit, env.convert_mem_ptr(value_offset), env.convert_mem_ptr(source_contract_address_offset), env.convert_mem_ptr(code_metadata_offset), env.convert_mem_ptr(result_address_offset), num_arguments, env.convert_mem_ptr(arguments_length_offset), env.convert_mem_ptr(data_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_num_return_data(env: &VMHooksWrapper) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_num_return_data())
+    env.vm_hooks.get_num_return_data()
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_return_data_size(env: &VMHooksWrapper, result_id: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_return_data_size(result_id))
+    env.vm_hooks.get_return_data_size(result_id)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_return_data(env: &VMHooksWrapper, result_id: i32, data_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_return_data(result_id, env.convert_mem_ptr(data_offset)))
+    env.vm_hooks.get_return_data(result_id, env.convert_mem_ptr(data_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_clean_return_data(env: &VMHooksWrapper) {
-    env.with_vm_hooks(|vh| vh.clean_return_data())
+    env.vm_hooks.clean_return_data()
 }
 
 #[rustfmt::skip]
 fn wasmer_import_delete_from_return_data(env: &VMHooksWrapper, result_id: i32) {
-    env.with_vm_hooks(|vh| vh.delete_from_return_data(result_id))
+    env.vm_hooks.delete_from_return_data(result_id)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_original_tx_hash(env: &VMHooksWrapper, data_offset: i32) {
-    env.with_vm_hooks(|vh| vh.get_original_tx_hash(env.convert_mem_ptr(data_offset)))
+    env.vm_hooks.get_original_tx_hash(env.convert_mem_ptr(data_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_current_tx_hash(env: &VMHooksWrapper, data_offset: i32) {
-    env.with_vm_hooks(|vh| vh.get_current_tx_hash(env.convert_mem_ptr(data_offset)))
+    env.vm_hooks.get_current_tx_hash(env.convert_mem_ptr(data_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_prev_tx_hash(env: &VMHooksWrapper, data_offset: i32) {
-    env.with_vm_hooks(|vh| vh.get_prev_tx_hash(env.convert_mem_ptr(data_offset)))
+    env.vm_hooks.get_prev_tx_hash(env.convert_mem_ptr(data_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_sc_address(env: &VMHooksWrapper, destination_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_sc_address(destination_handle))
+    env.vm_hooks.managed_sc_address(destination_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_owner_address(env: &VMHooksWrapper, destination_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_owner_address(destination_handle))
+    env.vm_hooks.managed_owner_address(destination_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_caller(env: &VMHooksWrapper, destination_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_caller(destination_handle))
+    env.vm_hooks.managed_caller(destination_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_get_original_caller_addr(env: &VMHooksWrapper, destination_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_get_original_caller_addr(destination_handle))
+    env.vm_hooks.managed_get_original_caller_addr(destination_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_get_relayer_addr(env: &VMHooksWrapper, destination_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_get_relayer_addr(destination_handle))
+    env.vm_hooks.managed_get_relayer_addr(destination_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_signal_error(env: &VMHooksWrapper, err_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_signal_error(err_handle))
+    env.vm_hooks.managed_signal_error(err_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_write_log(env: &VMHooksWrapper, topics_handle: i32, data_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_write_log(topics_handle, data_handle))
+    env.vm_hooks.managed_write_log(topics_handle, data_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_get_original_tx_hash(env: &VMHooksWrapper, result_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_get_original_tx_hash(result_handle))
+    env.vm_hooks.managed_get_original_tx_hash(result_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_get_state_root_hash(env: &VMHooksWrapper, result_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_get_state_root_hash(result_handle))
+    env.vm_hooks.managed_get_state_root_hash(result_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_get_block_random_seed(env: &VMHooksWrapper, result_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_get_block_random_seed(result_handle))
+    env.vm_hooks.managed_get_block_random_seed(result_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_get_prev_block_random_seed(env: &VMHooksWrapper, result_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_get_prev_block_random_seed(result_handle))
+    env.vm_hooks.managed_get_prev_block_random_seed(result_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_get_return_data(env: &VMHooksWrapper, result_id: i32, result_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_get_return_data(result_id, result_handle))
+    env.vm_hooks.managed_get_return_data(result_id, result_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_get_multi_esdt_call_value(env: &VMHooksWrapper, multi_call_value_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_get_multi_esdt_call_value(multi_call_value_handle))
+    env.vm_hooks.managed_get_multi_esdt_call_value(multi_call_value_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_get_back_transfers(env: &VMHooksWrapper, esdt_transfers_value_handle: i32, egld_value_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_get_back_transfers(esdt_transfers_value_handle, egld_value_handle))
+    env.vm_hooks.managed_get_back_transfers(esdt_transfers_value_handle, egld_value_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_get_esdt_balance(env: &VMHooksWrapper, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_get_esdt_balance(address_handle, token_id_handle, nonce, value_handle))
+    env.vm_hooks.managed_get_esdt_balance(address_handle, token_id_handle, nonce, value_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_get_esdt_token_data(env: &VMHooksWrapper, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32, properties_handle: i32, hash_handle: i32, name_handle: i32, attributes_handle: i32, creator_handle: i32, royalties_handle: i32, uris_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_get_esdt_token_data(address_handle, token_id_handle, nonce, value_handle, properties_handle, hash_handle, name_handle, attributes_handle, creator_handle, royalties_handle, uris_handle))
+    env.vm_hooks.managed_get_esdt_token_data(address_handle, token_id_handle, nonce, value_handle, properties_handle, hash_handle, name_handle, attributes_handle, creator_handle, royalties_handle, uris_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_async_call(env: &VMHooksWrapper, dest_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_async_call(dest_handle, value_handle, function_handle, arguments_handle))
+    env.vm_hooks.managed_async_call(dest_handle, value_handle, function_handle, arguments_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_create_async_call(env: &VMHooksWrapper, dest_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, success_offset: i32, success_length: i32, error_offset: i32, error_length: i32, gas: i64, extra_gas_for_callback: i64, callback_closure_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_create_async_call(dest_handle, value_handle, function_handle, arguments_handle, env.convert_mem_ptr(success_offset), env.convert_mem_length(success_length), env.convert_mem_ptr(error_offset), env.convert_mem_length(error_length), gas, extra_gas_for_callback, callback_closure_handle))
+    env.vm_hooks.managed_create_async_call(dest_handle, value_handle, function_handle, arguments_handle, env.convert_mem_ptr(success_offset), env.convert_mem_length(success_length), env.convert_mem_ptr(error_offset), env.convert_mem_length(error_length), gas, extra_gas_for_callback, callback_closure_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_get_callback_closure(env: &VMHooksWrapper, callback_closure_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_get_callback_closure(callback_closure_handle))
+    env.vm_hooks.managed_get_callback_closure(callback_closure_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_upgrade_from_source_contract(env: &VMHooksWrapper, dest_handle: i32, gas: i64, value_handle: i32, address_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_upgrade_from_source_contract(dest_handle, gas, value_handle, address_handle, code_metadata_handle, arguments_handle, result_handle))
+    env.vm_hooks.managed_upgrade_from_source_contract(dest_handle, gas, value_handle, address_handle, code_metadata_handle, arguments_handle, result_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_upgrade_contract(env: &VMHooksWrapper, dest_handle: i32, gas: i64, value_handle: i32, code_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_upgrade_contract(dest_handle, gas, value_handle, code_handle, code_metadata_handle, arguments_handle, result_handle))
+    env.vm_hooks.managed_upgrade_contract(dest_handle, gas, value_handle, code_handle, code_metadata_handle, arguments_handle, result_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_delete_contract(env: &VMHooksWrapper, dest_handle: i32, gas_limit: i64, arguments_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_delete_contract(dest_handle, gas_limit, arguments_handle))
+    env.vm_hooks.managed_delete_contract(dest_handle, gas_limit, arguments_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_deploy_from_source_contract(env: &VMHooksWrapper, gas: i64, value_handle: i32, address_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_address_handle: i32, result_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_deploy_from_source_contract(gas, value_handle, address_handle, code_metadata_handle, arguments_handle, result_address_handle, result_handle))
+    env.vm_hooks.managed_deploy_from_source_contract(gas, value_handle, address_handle, code_metadata_handle, arguments_handle, result_address_handle, result_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_create_contract(env: &VMHooksWrapper, gas: i64, value_handle: i32, code_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_address_handle: i32, result_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_create_contract(gas, value_handle, code_handle, code_metadata_handle, arguments_handle, result_address_handle, result_handle))
+    env.vm_hooks.managed_create_contract(gas, value_handle, code_handle, code_metadata_handle, arguments_handle, result_address_handle, result_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_execute_read_only(env: &VMHooksWrapper, gas: i64, address_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_execute_read_only(gas, address_handle, function_handle, arguments_handle, result_handle))
+    env.vm_hooks.managed_execute_read_only(gas, address_handle, function_handle, arguments_handle, result_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_execute_on_same_context(env: &VMHooksWrapper, gas: i64, address_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_execute_on_same_context(gas, address_handle, value_handle, function_handle, arguments_handle, result_handle))
+    env.vm_hooks.managed_execute_on_same_context(gas, address_handle, value_handle, function_handle, arguments_handle, result_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_execute_on_dest_context(env: &VMHooksWrapper, gas: i64, address_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_execute_on_dest_context(gas, address_handle, value_handle, function_handle, arguments_handle, result_handle))
+    env.vm_hooks.managed_execute_on_dest_context(gas, address_handle, value_handle, function_handle, arguments_handle, result_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_multi_transfer_esdt_nft_execute(env: &VMHooksWrapper, dst_handle: i32, token_transfers_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_multi_transfer_esdt_nft_execute(dst_handle, token_transfers_handle, gas_limit, function_handle, arguments_handle))
+    env.vm_hooks.managed_multi_transfer_esdt_nft_execute(dst_handle, token_transfers_handle, gas_limit, function_handle, arguments_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_multi_transfer_esdt_nft_execute_by_user(env: &VMHooksWrapper, user_handle: i32, dst_handle: i32, token_transfers_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_multi_transfer_esdt_nft_execute_by_user(user_handle, dst_handle, token_transfers_handle, gas_limit, function_handle, arguments_handle))
+    env.vm_hooks.managed_multi_transfer_esdt_nft_execute_by_user(user_handle, dst_handle, token_transfers_handle, gas_limit, function_handle, arguments_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_transfer_value_execute(env: &VMHooksWrapper, dst_handle: i32, value_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_transfer_value_execute(dst_handle, value_handle, gas_limit, function_handle, arguments_handle))
+    env.vm_hooks.managed_transfer_value_execute(dst_handle, value_handle, gas_limit, function_handle, arguments_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_is_esdt_frozen(env: &VMHooksWrapper, address_handle: i32, token_id_handle: i32, nonce: i64) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_is_esdt_frozen(address_handle, token_id_handle, nonce))
+    env.vm_hooks.managed_is_esdt_frozen(address_handle, token_id_handle, nonce)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_is_esdt_limited_transfer(env: &VMHooksWrapper, token_id_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_is_esdt_limited_transfer(token_id_handle))
+    env.vm_hooks.managed_is_esdt_limited_transfer(token_id_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_is_esdt_paused(env: &VMHooksWrapper, token_id_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_is_esdt_paused(token_id_handle))
+    env.vm_hooks.managed_is_esdt_paused(token_id_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_buffer_to_hex(env: &VMHooksWrapper, source_handle: i32, dest_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_buffer_to_hex(source_handle, dest_handle))
+    env.vm_hooks.managed_buffer_to_hex(source_handle, dest_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_get_code_metadata(env: &VMHooksWrapper, address_handle: i32, response_handle: i32) {
-    env.with_vm_hooks(|vh| vh.managed_get_code_metadata(address_handle, response_handle))
+    env.vm_hooks.managed_get_code_metadata(address_handle, response_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_is_builtin_function(env: &VMHooksWrapper, function_name_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_is_builtin_function(function_name_handle))
+    env.vm_hooks.managed_is_builtin_function(function_name_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_new_from_parts(env: &VMHooksWrapper, integral_part: i32, fractional_part: i32, exponent: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.big_float_new_from_parts(integral_part, fractional_part, exponent))
+    env.vm_hooks.big_float_new_from_parts(integral_part, fractional_part, exponent)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_new_from_frac(env: &VMHooksWrapper, numerator: i64, denominator: i64) -> i32 {
-    env.with_vm_hooks(|vh| vh.big_float_new_from_frac(numerator, denominator))
+    env.vm_hooks.big_float_new_from_frac(numerator, denominator)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_new_from_sci(env: &VMHooksWrapper, significand: i64, exponent: i64) -> i32 {
-    env.with_vm_hooks(|vh| vh.big_float_new_from_sci(significand, exponent))
+    env.vm_hooks.big_float_new_from_sci(significand, exponent)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_add(env: &VMHooksWrapper, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_float_add(destination_handle, op1_handle, op2_handle))
+    env.vm_hooks.big_float_add(destination_handle, op1_handle, op2_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_sub(env: &VMHooksWrapper, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_float_sub(destination_handle, op1_handle, op2_handle))
+    env.vm_hooks.big_float_sub(destination_handle, op1_handle, op2_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_mul(env: &VMHooksWrapper, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_float_mul(destination_handle, op1_handle, op2_handle))
+    env.vm_hooks.big_float_mul(destination_handle, op1_handle, op2_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_div(env: &VMHooksWrapper, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_float_div(destination_handle, op1_handle, op2_handle))
+    env.vm_hooks.big_float_div(destination_handle, op1_handle, op2_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_neg(env: &VMHooksWrapper, destination_handle: i32, op_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_float_neg(destination_handle, op_handle))
+    env.vm_hooks.big_float_neg(destination_handle, op_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_clone(env: &VMHooksWrapper, destination_handle: i32, op_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_float_clone(destination_handle, op_handle))
+    env.vm_hooks.big_float_clone(destination_handle, op_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_cmp(env: &VMHooksWrapper, op1_handle: i32, op2_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.big_float_cmp(op1_handle, op2_handle))
+    env.vm_hooks.big_float_cmp(op1_handle, op2_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_abs(env: &VMHooksWrapper, destination_handle: i32, op_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_float_abs(destination_handle, op_handle))
+    env.vm_hooks.big_float_abs(destination_handle, op_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_sign(env: &VMHooksWrapper, op_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.big_float_sign(op_handle))
+    env.vm_hooks.big_float_sign(op_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_sqrt(env: &VMHooksWrapper, destination_handle: i32, op_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_float_sqrt(destination_handle, op_handle))
+    env.vm_hooks.big_float_sqrt(destination_handle, op_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_pow(env: &VMHooksWrapper, destination_handle: i32, op_handle: i32, exponent: i32) {
-    env.with_vm_hooks(|vh| vh.big_float_pow(destination_handle, op_handle, exponent))
+    env.vm_hooks.big_float_pow(destination_handle, op_handle, exponent)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_floor(env: &VMHooksWrapper, dest_big_int_handle: i32, op_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_float_floor(dest_big_int_handle, op_handle))
+    env.vm_hooks.big_float_floor(dest_big_int_handle, op_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_ceil(env: &VMHooksWrapper, dest_big_int_handle: i32, op_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_float_ceil(dest_big_int_handle, op_handle))
+    env.vm_hooks.big_float_ceil(dest_big_int_handle, op_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_truncate(env: &VMHooksWrapper, dest_big_int_handle: i32, op_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_float_truncate(dest_big_int_handle, op_handle))
+    env.vm_hooks.big_float_truncate(dest_big_int_handle, op_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_set_int64(env: &VMHooksWrapper, destination_handle: i32, value: i64) {
-    env.with_vm_hooks(|vh| vh.big_float_set_int64(destination_handle, value))
+    env.vm_hooks.big_float_set_int64(destination_handle, value)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_is_int(env: &VMHooksWrapper, op_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.big_float_is_int(op_handle))
+    env.vm_hooks.big_float_is_int(op_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_set_big_int(env: &VMHooksWrapper, destination_handle: i32, big_int_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_float_set_big_int(destination_handle, big_int_handle))
+    env.vm_hooks.big_float_set_big_int(destination_handle, big_int_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_get_const_pi(env: &VMHooksWrapper, destination_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_float_get_const_pi(destination_handle))
+    env.vm_hooks.big_float_get_const_pi(destination_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_float_get_const_e(env: &VMHooksWrapper, destination_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_float_get_const_e(destination_handle))
+    env.vm_hooks.big_float_get_const_e(destination_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_get_unsigned_argument(env: &VMHooksWrapper, id: i32, destination_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_get_unsigned_argument(id, destination_handle))
+    env.vm_hooks.big_int_get_unsigned_argument(id, destination_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_get_signed_argument(env: &VMHooksWrapper, id: i32, destination_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_get_signed_argument(id, destination_handle))
+    env.vm_hooks.big_int_get_signed_argument(id, destination_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_storage_store_unsigned(env: &VMHooksWrapper, key_offset: i32, key_length: i32, source_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.big_int_storage_store_unsigned(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), source_handle))
+    env.vm_hooks.big_int_storage_store_unsigned(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), source_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_storage_load_unsigned(env: &VMHooksWrapper, key_offset: i32, key_length: i32, destination_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.big_int_storage_load_unsigned(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), destination_handle))
+    env.vm_hooks.big_int_storage_load_unsigned(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), destination_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_get_call_value(env: &VMHooksWrapper, destination_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_get_call_value(destination_handle))
+    env.vm_hooks.big_int_get_call_value(destination_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_get_esdt_call_value(env: &VMHooksWrapper, destination: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_get_esdt_call_value(destination))
+    env.vm_hooks.big_int_get_esdt_call_value(destination)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_get_esdt_call_value_by_index(env: &VMHooksWrapper, destination_handle: i32, index: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_get_esdt_call_value_by_index(destination_handle, index))
+    env.vm_hooks.big_int_get_esdt_call_value_by_index(destination_handle, index)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_get_external_balance(env: &VMHooksWrapper, address_offset: i32, result: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_get_external_balance(env.convert_mem_ptr(address_offset), result))
+    env.vm_hooks.big_int_get_external_balance(env.convert_mem_ptr(address_offset), result)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_get_esdt_external_balance(env: &VMHooksWrapper, address_offset: i32, token_id_offset: i32, token_id_len: i32, nonce: i64, result_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_get_esdt_external_balance(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), nonce, result_handle))
+    env.vm_hooks.big_int_get_esdt_external_balance(env.convert_mem_ptr(address_offset), env.convert_mem_ptr(token_id_offset), env.convert_mem_length(token_id_len), nonce, result_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_new(env: &VMHooksWrapper, small_value: i64) -> i32 {
-    env.with_vm_hooks(|vh| vh.big_int_new(small_value))
+    env.vm_hooks.big_int_new(small_value)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_unsigned_byte_length(env: &VMHooksWrapper, reference_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.big_int_unsigned_byte_length(reference_handle))
+    env.vm_hooks.big_int_unsigned_byte_length(reference_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_signed_byte_length(env: &VMHooksWrapper, reference_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.big_int_signed_byte_length(reference_handle))
+    env.vm_hooks.big_int_signed_byte_length(reference_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_get_unsigned_bytes(env: &VMHooksWrapper, reference_handle: i32, byte_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.big_int_get_unsigned_bytes(reference_handle, env.convert_mem_ptr(byte_offset)))
+    env.vm_hooks.big_int_get_unsigned_bytes(reference_handle, env.convert_mem_ptr(byte_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_get_signed_bytes(env: &VMHooksWrapper, reference_handle: i32, byte_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.big_int_get_signed_bytes(reference_handle, env.convert_mem_ptr(byte_offset)))
+    env.vm_hooks.big_int_get_signed_bytes(reference_handle, env.convert_mem_ptr(byte_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_set_unsigned_bytes(env: &VMHooksWrapper, destination_handle: i32, byte_offset: i32, byte_length: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_set_unsigned_bytes(destination_handle, env.convert_mem_ptr(byte_offset), env.convert_mem_length(byte_length)))
+    env.vm_hooks.big_int_set_unsigned_bytes(destination_handle, env.convert_mem_ptr(byte_offset), env.convert_mem_length(byte_length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_set_signed_bytes(env: &VMHooksWrapper, destination_handle: i32, byte_offset: i32, byte_length: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_set_signed_bytes(destination_handle, env.convert_mem_ptr(byte_offset), env.convert_mem_length(byte_length)))
+    env.vm_hooks.big_int_set_signed_bytes(destination_handle, env.convert_mem_ptr(byte_offset), env.convert_mem_length(byte_length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_is_int64(env: &VMHooksWrapper, destination_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.big_int_is_int64(destination_handle))
+    env.vm_hooks.big_int_is_int64(destination_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_get_int64(env: &VMHooksWrapper, destination_handle: i32) -> i64 {
-    env.with_vm_hooks(|vh| vh.big_int_get_int64(destination_handle))
+    env.vm_hooks.big_int_get_int64(destination_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_set_int64(env: &VMHooksWrapper, destination_handle: i32, value: i64) {
-    env.with_vm_hooks(|vh| vh.big_int_set_int64(destination_handle, value))
+    env.vm_hooks.big_int_set_int64(destination_handle, value)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_add(env: &VMHooksWrapper, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_add(destination_handle, op1_handle, op2_handle))
+    env.vm_hooks.big_int_add(destination_handle, op1_handle, op2_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_sub(env: &VMHooksWrapper, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_sub(destination_handle, op1_handle, op2_handle))
+    env.vm_hooks.big_int_sub(destination_handle, op1_handle, op2_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_mul(env: &VMHooksWrapper, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_mul(destination_handle, op1_handle, op2_handle))
+    env.vm_hooks.big_int_mul(destination_handle, op1_handle, op2_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_tdiv(env: &VMHooksWrapper, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_tdiv(destination_handle, op1_handle, op2_handle))
+    env.vm_hooks.big_int_tdiv(destination_handle, op1_handle, op2_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_tmod(env: &VMHooksWrapper, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_tmod(destination_handle, op1_handle, op2_handle))
+    env.vm_hooks.big_int_tmod(destination_handle, op1_handle, op2_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_ediv(env: &VMHooksWrapper, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_ediv(destination_handle, op1_handle, op2_handle))
+    env.vm_hooks.big_int_ediv(destination_handle, op1_handle, op2_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_emod(env: &VMHooksWrapper, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_emod(destination_handle, op1_handle, op2_handle))
+    env.vm_hooks.big_int_emod(destination_handle, op1_handle, op2_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_sqrt(env: &VMHooksWrapper, destination_handle: i32, op_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_sqrt(destination_handle, op_handle))
+    env.vm_hooks.big_int_sqrt(destination_handle, op_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_pow(env: &VMHooksWrapper, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_pow(destination_handle, op1_handle, op2_handle))
+    env.vm_hooks.big_int_pow(destination_handle, op1_handle, op2_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_log2(env: &VMHooksWrapper, op1_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.big_int_log2(op1_handle))
+    env.vm_hooks.big_int_log2(op1_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_abs(env: &VMHooksWrapper, destination_handle: i32, op_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_abs(destination_handle, op_handle))
+    env.vm_hooks.big_int_abs(destination_handle, op_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_neg(env: &VMHooksWrapper, destination_handle: i32, op_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_neg(destination_handle, op_handle))
+    env.vm_hooks.big_int_neg(destination_handle, op_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_sign(env: &VMHooksWrapper, op_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.big_int_sign(op_handle))
+    env.vm_hooks.big_int_sign(op_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_cmp(env: &VMHooksWrapper, op1_handle: i32, op2_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.big_int_cmp(op1_handle, op2_handle))
+    env.vm_hooks.big_int_cmp(op1_handle, op2_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_not(env: &VMHooksWrapper, destination_handle: i32, op_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_not(destination_handle, op_handle))
+    env.vm_hooks.big_int_not(destination_handle, op_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_and(env: &VMHooksWrapper, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_and(destination_handle, op1_handle, op2_handle))
+    env.vm_hooks.big_int_and(destination_handle, op1_handle, op2_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_or(env: &VMHooksWrapper, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_or(destination_handle, op1_handle, op2_handle))
+    env.vm_hooks.big_int_or(destination_handle, op1_handle, op2_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_xor(env: &VMHooksWrapper, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_xor(destination_handle, op1_handle, op2_handle))
+    env.vm_hooks.big_int_xor(destination_handle, op1_handle, op2_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_shr(env: &VMHooksWrapper, destination_handle: i32, op_handle: i32, bits: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_shr(destination_handle, op_handle, bits))
+    env.vm_hooks.big_int_shr(destination_handle, op_handle, bits)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_shl(env: &VMHooksWrapper, destination_handle: i32, op_handle: i32, bits: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_shl(destination_handle, op_handle, bits))
+    env.vm_hooks.big_int_shl(destination_handle, op_handle, bits)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_finish_unsigned(env: &VMHooksWrapper, reference_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_finish_unsigned(reference_handle))
+    env.vm_hooks.big_int_finish_unsigned(reference_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_finish_signed(env: &VMHooksWrapper, reference_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_finish_signed(reference_handle))
+    env.vm_hooks.big_int_finish_signed(reference_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_big_int_to_string(env: &VMHooksWrapper, big_int_handle: i32, destination_handle: i32) {
-    env.with_vm_hooks(|vh| vh.big_int_to_string(big_int_handle, destination_handle))
+    env.vm_hooks.big_int_to_string(big_int_handle, destination_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_new(env: &VMHooksWrapper) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_new())
+    env.vm_hooks.mbuffer_new()
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_new_from_bytes(env: &VMHooksWrapper, data_offset: i32, data_length: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_new_from_bytes(env.convert_mem_ptr(data_offset), env.convert_mem_length(data_length)))
+    env.vm_hooks.mbuffer_new_from_bytes(env.convert_mem_ptr(data_offset), env.convert_mem_length(data_length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_get_length(env: &VMHooksWrapper, m_buffer_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_get_length(m_buffer_handle))
+    env.vm_hooks.mbuffer_get_length(m_buffer_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_get_bytes(env: &VMHooksWrapper, m_buffer_handle: i32, result_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_get_bytes(m_buffer_handle, env.convert_mem_ptr(result_offset)))
+    env.vm_hooks.mbuffer_get_bytes(m_buffer_handle, env.convert_mem_ptr(result_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_get_byte_slice(env: &VMHooksWrapper, source_handle: i32, starting_position: i32, slice_length: i32, result_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_get_byte_slice(source_handle, starting_position, slice_length, env.convert_mem_ptr(result_offset)))
+    env.vm_hooks.mbuffer_get_byte_slice(source_handle, starting_position, slice_length, env.convert_mem_ptr(result_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_copy_byte_slice(env: &VMHooksWrapper, source_handle: i32, starting_position: i32, slice_length: i32, destination_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_copy_byte_slice(source_handle, starting_position, slice_length, destination_handle))
+    env.vm_hooks.mbuffer_copy_byte_slice(source_handle, starting_position, slice_length, destination_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_eq(env: &VMHooksWrapper, m_buffer_handle1: i32, m_buffer_handle2: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_eq(m_buffer_handle1, m_buffer_handle2))
+    env.vm_hooks.mbuffer_eq(m_buffer_handle1, m_buffer_handle2)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_set_bytes(env: &VMHooksWrapper, m_buffer_handle: i32, data_offset: i32, data_length: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_set_bytes(m_buffer_handle, env.convert_mem_ptr(data_offset), env.convert_mem_length(data_length)))
+    env.vm_hooks.mbuffer_set_bytes(m_buffer_handle, env.convert_mem_ptr(data_offset), env.convert_mem_length(data_length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_set_byte_slice(env: &VMHooksWrapper, m_buffer_handle: i32, starting_position: i32, data_length: i32, data_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_set_byte_slice(m_buffer_handle, starting_position, env.convert_mem_length(data_length), env.convert_mem_ptr(data_offset)))
+    env.vm_hooks.mbuffer_set_byte_slice(m_buffer_handle, starting_position, env.convert_mem_length(data_length), env.convert_mem_ptr(data_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_append(env: &VMHooksWrapper, accumulator_handle: i32, data_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_append(accumulator_handle, data_handle))
+    env.vm_hooks.mbuffer_append(accumulator_handle, data_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_append_bytes(env: &VMHooksWrapper, accumulator_handle: i32, data_offset: i32, data_length: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_append_bytes(accumulator_handle, env.convert_mem_ptr(data_offset), env.convert_mem_length(data_length)))
+    env.vm_hooks.mbuffer_append_bytes(accumulator_handle, env.convert_mem_ptr(data_offset), env.convert_mem_length(data_length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_to_big_int_unsigned(env: &VMHooksWrapper, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_to_big_int_unsigned(m_buffer_handle, big_int_handle))
+    env.vm_hooks.mbuffer_to_big_int_unsigned(m_buffer_handle, big_int_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_to_big_int_signed(env: &VMHooksWrapper, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_to_big_int_signed(m_buffer_handle, big_int_handle))
+    env.vm_hooks.mbuffer_to_big_int_signed(m_buffer_handle, big_int_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_from_big_int_unsigned(env: &VMHooksWrapper, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_from_big_int_unsigned(m_buffer_handle, big_int_handle))
+    env.vm_hooks.mbuffer_from_big_int_unsigned(m_buffer_handle, big_int_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_from_big_int_signed(env: &VMHooksWrapper, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_from_big_int_signed(m_buffer_handle, big_int_handle))
+    env.vm_hooks.mbuffer_from_big_int_signed(m_buffer_handle, big_int_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_to_big_float(env: &VMHooksWrapper, m_buffer_handle: i32, big_float_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_to_big_float(m_buffer_handle, big_float_handle))
+    env.vm_hooks.mbuffer_to_big_float(m_buffer_handle, big_float_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_from_big_float(env: &VMHooksWrapper, m_buffer_handle: i32, big_float_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_from_big_float(m_buffer_handle, big_float_handle))
+    env.vm_hooks.mbuffer_from_big_float(m_buffer_handle, big_float_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_storage_store(env: &VMHooksWrapper, key_handle: i32, source_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_storage_store(key_handle, source_handle))
+    env.vm_hooks.mbuffer_storage_store(key_handle, source_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_storage_load(env: &VMHooksWrapper, key_handle: i32, destination_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_storage_load(key_handle, destination_handle))
+    env.vm_hooks.mbuffer_storage_load(key_handle, destination_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_storage_load_from_address(env: &VMHooksWrapper, address_handle: i32, key_handle: i32, destination_handle: i32) {
-    env.with_vm_hooks(|vh| vh.mbuffer_storage_load_from_address(address_handle, key_handle, destination_handle))
+    env.vm_hooks.mbuffer_storage_load_from_address(address_handle, key_handle, destination_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_get_argument(env: &VMHooksWrapper, id: i32, destination_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_get_argument(id, destination_handle))
+    env.vm_hooks.mbuffer_get_argument(id, destination_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_finish(env: &VMHooksWrapper, source_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_finish(source_handle))
+    env.vm_hooks.mbuffer_finish(source_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_mbuffer_set_random(env: &VMHooksWrapper, destination_handle: i32, length: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.mbuffer_set_random(destination_handle, length))
+    env.vm_hooks.mbuffer_set_random(destination_handle, length)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_map_new(env: &VMHooksWrapper) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_map_new())
+    env.vm_hooks.managed_map_new()
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_map_put(env: &VMHooksWrapper, m_map_handle: i32, key_handle: i32, value_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_map_put(m_map_handle, key_handle, value_handle))
+    env.vm_hooks.managed_map_put(m_map_handle, key_handle, value_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_map_get(env: &VMHooksWrapper, m_map_handle: i32, key_handle: i32, out_value_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_map_get(m_map_handle, key_handle, out_value_handle))
+    env.vm_hooks.managed_map_get(m_map_handle, key_handle, out_value_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_map_remove(env: &VMHooksWrapper, m_map_handle: i32, key_handle: i32, out_value_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_map_remove(m_map_handle, key_handle, out_value_handle))
+    env.vm_hooks.managed_map_remove(m_map_handle, key_handle, out_value_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_map_contains(env: &VMHooksWrapper, m_map_handle: i32, key_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_map_contains(m_map_handle, key_handle))
+    env.vm_hooks.managed_map_contains(m_map_handle, key_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_small_int_get_unsigned_argument(env: &VMHooksWrapper, id: i32) -> i64 {
-    env.with_vm_hooks(|vh| vh.small_int_get_unsigned_argument(id))
+    env.vm_hooks.small_int_get_unsigned_argument(id)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_small_int_get_signed_argument(env: &VMHooksWrapper, id: i32) -> i64 {
-    env.with_vm_hooks(|vh| vh.small_int_get_signed_argument(id))
+    env.vm_hooks.small_int_get_signed_argument(id)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_small_int_finish_unsigned(env: &VMHooksWrapper, value: i64) {
-    env.with_vm_hooks(|vh| vh.small_int_finish_unsigned(value))
+    env.vm_hooks.small_int_finish_unsigned(value)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_small_int_finish_signed(env: &VMHooksWrapper, value: i64) {
-    env.with_vm_hooks(|vh| vh.small_int_finish_signed(value))
+    env.vm_hooks.small_int_finish_signed(value)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_small_int_storage_store_unsigned(env: &VMHooksWrapper, key_offset: i32, key_length: i32, value: i64) -> i32 {
-    env.with_vm_hooks(|vh| vh.small_int_storage_store_unsigned(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), value))
+    env.vm_hooks.small_int_storage_store_unsigned(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), value)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_small_int_storage_store_signed(env: &VMHooksWrapper, key_offset: i32, key_length: i32, value: i64) -> i32 {
-    env.with_vm_hooks(|vh| vh.small_int_storage_store_signed(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), value))
+    env.vm_hooks.small_int_storage_store_signed(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), value)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_small_int_storage_load_unsigned(env: &VMHooksWrapper, key_offset: i32, key_length: i32) -> i64 {
-    env.with_vm_hooks(|vh| vh.small_int_storage_load_unsigned(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length)))
+    env.vm_hooks.small_int_storage_load_unsigned(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_small_int_storage_load_signed(env: &VMHooksWrapper, key_offset: i32, key_length: i32) -> i64 {
-    env.with_vm_hooks(|vh| vh.small_int_storage_load_signed(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length)))
+    env.vm_hooks.small_int_storage_load_signed(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_int64get_argument(env: &VMHooksWrapper, id: i32) -> i64 {
-    env.with_vm_hooks(|vh| vh.int64get_argument(id))
+    env.vm_hooks.int64get_argument(id)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_int64finish(env: &VMHooksWrapper, value: i64) {
-    env.with_vm_hooks(|vh| vh.int64finish(value))
+    env.vm_hooks.int64finish(value)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_int64storage_store(env: &VMHooksWrapper, key_offset: i32, key_length: i32, value: i64) -> i32 {
-    env.with_vm_hooks(|vh| vh.int64storage_store(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), value))
+    env.vm_hooks.int64storage_store(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), value)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_int64storage_load(env: &VMHooksWrapper, key_offset: i32, key_length: i32) -> i64 {
-    env.with_vm_hooks(|vh| vh.int64storage_load(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length)))
+    env.vm_hooks.int64storage_load(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_sha256(env: &VMHooksWrapper, data_offset: i32, length: i32, result_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.sha256(env.convert_mem_ptr(data_offset), env.convert_mem_length(length), env.convert_mem_ptr(result_offset)))
+    env.vm_hooks.sha256(env.convert_mem_ptr(data_offset), env.convert_mem_length(length), env.convert_mem_ptr(result_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_sha256(env: &VMHooksWrapper, input_handle: i32, output_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_sha256(input_handle, output_handle))
+    env.vm_hooks.managed_sha256(input_handle, output_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_keccak256(env: &VMHooksWrapper, data_offset: i32, length: i32, result_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.keccak256(env.convert_mem_ptr(data_offset), env.convert_mem_length(length), env.convert_mem_ptr(result_offset)))
+    env.vm_hooks.keccak256(env.convert_mem_ptr(data_offset), env.convert_mem_length(length), env.convert_mem_ptr(result_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_keccak256(env: &VMHooksWrapper, input_handle: i32, output_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_keccak256(input_handle, output_handle))
+    env.vm_hooks.managed_keccak256(input_handle, output_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_ripemd160(env: &VMHooksWrapper, data_offset: i32, length: i32, result_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.ripemd160(env.convert_mem_ptr(data_offset), env.convert_mem_length(length), env.convert_mem_ptr(result_offset)))
+    env.vm_hooks.ripemd160(env.convert_mem_ptr(data_offset), env.convert_mem_length(length), env.convert_mem_ptr(result_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_ripemd160(env: &VMHooksWrapper, input_handle: i32, output_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_ripemd160(input_handle, output_handle))
+    env.vm_hooks.managed_ripemd160(input_handle, output_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_verify_bls(env: &VMHooksWrapper, key_offset: i32, message_offset: i32, message_length: i32, sig_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.verify_bls(env.convert_mem_ptr(key_offset), env.convert_mem_ptr(message_offset), env.convert_mem_length(message_length), env.convert_mem_ptr(sig_offset)))
+    env.vm_hooks.verify_bls(env.convert_mem_ptr(key_offset), env.convert_mem_ptr(message_offset), env.convert_mem_length(message_length), env.convert_mem_ptr(sig_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_verify_bls(env: &VMHooksWrapper, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_verify_bls(key_handle, message_handle, sig_handle))
+    env.vm_hooks.managed_verify_bls(key_handle, message_handle, sig_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_verify_ed25519(env: &VMHooksWrapper, key_offset: i32, message_offset: i32, message_length: i32, sig_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.verify_ed25519(env.convert_mem_ptr(key_offset), env.convert_mem_ptr(message_offset), env.convert_mem_length(message_length), env.convert_mem_ptr(sig_offset)))
+    env.vm_hooks.verify_ed25519(env.convert_mem_ptr(key_offset), env.convert_mem_ptr(message_offset), env.convert_mem_length(message_length), env.convert_mem_ptr(sig_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_verify_ed25519(env: &VMHooksWrapper, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_verify_ed25519(key_handle, message_handle, sig_handle))
+    env.vm_hooks.managed_verify_ed25519(key_handle, message_handle, sig_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_verify_custom_secp256k1(env: &VMHooksWrapper, key_offset: i32, key_length: i32, message_offset: i32, message_length: i32, sig_offset: i32, hash_type: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.verify_custom_secp256k1(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), env.convert_mem_ptr(message_offset), env.convert_mem_length(message_length), env.convert_mem_ptr(sig_offset), hash_type))
+    env.vm_hooks.verify_custom_secp256k1(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), env.convert_mem_ptr(message_offset), env.convert_mem_length(message_length), env.convert_mem_ptr(sig_offset), hash_type)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_verify_custom_secp256k1(env: &VMHooksWrapper, key_handle: i32, message_handle: i32, sig_handle: i32, hash_type: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_verify_custom_secp256k1(key_handle, message_handle, sig_handle, hash_type))
+    env.vm_hooks.managed_verify_custom_secp256k1(key_handle, message_handle, sig_handle, hash_type)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_verify_secp256k1(env: &VMHooksWrapper, key_offset: i32, key_length: i32, message_offset: i32, message_length: i32, sig_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.verify_secp256k1(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), env.convert_mem_ptr(message_offset), env.convert_mem_length(message_length), env.convert_mem_ptr(sig_offset)))
+    env.vm_hooks.verify_secp256k1(env.convert_mem_ptr(key_offset), env.convert_mem_length(key_length), env.convert_mem_ptr(message_offset), env.convert_mem_length(message_length), env.convert_mem_ptr(sig_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_verify_secp256k1(env: &VMHooksWrapper, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_verify_secp256k1(key_handle, message_handle, sig_handle))
+    env.vm_hooks.managed_verify_secp256k1(key_handle, message_handle, sig_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_encode_secp256k1_der_signature(env: &VMHooksWrapper, r_offset: i32, r_length: i32, s_offset: i32, s_length: i32, sig_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.encode_secp256k1_der_signature(env.convert_mem_ptr(r_offset), env.convert_mem_length(r_length), env.convert_mem_ptr(s_offset), env.convert_mem_length(s_length), env.convert_mem_ptr(sig_offset)))
+    env.vm_hooks.encode_secp256k1_der_signature(env.convert_mem_ptr(r_offset), env.convert_mem_length(r_length), env.convert_mem_ptr(s_offset), env.convert_mem_length(s_length), env.convert_mem_ptr(sig_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_encode_secp256k1_der_signature(env: &VMHooksWrapper, r_handle: i32, s_handle: i32, sig_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_encode_secp256k1_der_signature(r_handle, s_handle, sig_handle))
+    env.vm_hooks.managed_encode_secp256k1_der_signature(r_handle, s_handle, sig_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_add_ec(env: &VMHooksWrapper, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, fst_point_xhandle: i32, fst_point_yhandle: i32, snd_point_xhandle: i32, snd_point_yhandle: i32) {
-    env.with_vm_hooks(|vh| vh.add_ec(x_result_handle, y_result_handle, ec_handle, fst_point_xhandle, fst_point_yhandle, snd_point_xhandle, snd_point_yhandle))
+    env.vm_hooks.add_ec(x_result_handle, y_result_handle, ec_handle, fst_point_xhandle, fst_point_yhandle, snd_point_xhandle, snd_point_yhandle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_double_ec(env: &VMHooksWrapper, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32) {
-    env.with_vm_hooks(|vh| vh.double_ec(x_result_handle, y_result_handle, ec_handle, point_xhandle, point_yhandle))
+    env.vm_hooks.double_ec(x_result_handle, y_result_handle, ec_handle, point_xhandle, point_yhandle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_is_on_curve_ec(env: &VMHooksWrapper, ec_handle: i32, point_xhandle: i32, point_yhandle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.is_on_curve_ec(ec_handle, point_xhandle, point_yhandle))
+    env.vm_hooks.is_on_curve_ec(ec_handle, point_xhandle, point_yhandle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_scalar_base_mult_ec(env: &VMHooksWrapper, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: i32, length: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.scalar_base_mult_ec(x_result_handle, y_result_handle, ec_handle, env.convert_mem_ptr(data_offset), env.convert_mem_length(length)))
+    env.vm_hooks.scalar_base_mult_ec(x_result_handle, y_result_handle, ec_handle, env.convert_mem_ptr(data_offset), env.convert_mem_length(length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_scalar_base_mult_ec(env: &VMHooksWrapper, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_scalar_base_mult_ec(x_result_handle, y_result_handle, ec_handle, data_handle))
+    env.vm_hooks.managed_scalar_base_mult_ec(x_result_handle, y_result_handle, ec_handle, data_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_scalar_mult_ec(env: &VMHooksWrapper, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32, data_offset: i32, length: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.scalar_mult_ec(x_result_handle, y_result_handle, ec_handle, point_xhandle, point_yhandle, env.convert_mem_ptr(data_offset), env.convert_mem_length(length)))
+    env.vm_hooks.scalar_mult_ec(x_result_handle, y_result_handle, ec_handle, point_xhandle, point_yhandle, env.convert_mem_ptr(data_offset), env.convert_mem_length(length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_scalar_mult_ec(env: &VMHooksWrapper, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32, data_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_scalar_mult_ec(x_result_handle, y_result_handle, ec_handle, point_xhandle, point_yhandle, data_handle))
+    env.vm_hooks.managed_scalar_mult_ec(x_result_handle, y_result_handle, ec_handle, point_xhandle, point_yhandle, data_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_marshal_ec(env: &VMHooksWrapper, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.marshal_ec(x_pair_handle, y_pair_handle, ec_handle, env.convert_mem_ptr(result_offset)))
+    env.vm_hooks.marshal_ec(x_pair_handle, y_pair_handle, ec_handle, env.convert_mem_ptr(result_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_marshal_ec(env: &VMHooksWrapper, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_marshal_ec(x_pair_handle, y_pair_handle, ec_handle, result_handle))
+    env.vm_hooks.managed_marshal_ec(x_pair_handle, y_pair_handle, ec_handle, result_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_marshal_compressed_ec(env: &VMHooksWrapper, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.marshal_compressed_ec(x_pair_handle, y_pair_handle, ec_handle, env.convert_mem_ptr(result_offset)))
+    env.vm_hooks.marshal_compressed_ec(x_pair_handle, y_pair_handle, ec_handle, env.convert_mem_ptr(result_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_marshal_compressed_ec(env: &VMHooksWrapper, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_marshal_compressed_ec(x_pair_handle, y_pair_handle, ec_handle, result_handle))
+    env.vm_hooks.managed_marshal_compressed_ec(x_pair_handle, y_pair_handle, ec_handle, result_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_unmarshal_ec(env: &VMHooksWrapper, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: i32, length: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.unmarshal_ec(x_result_handle, y_result_handle, ec_handle, env.convert_mem_ptr(data_offset), env.convert_mem_length(length)))
+    env.vm_hooks.unmarshal_ec(x_result_handle, y_result_handle, ec_handle, env.convert_mem_ptr(data_offset), env.convert_mem_length(length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_unmarshal_ec(env: &VMHooksWrapper, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_unmarshal_ec(x_result_handle, y_result_handle, ec_handle, data_handle))
+    env.vm_hooks.managed_unmarshal_ec(x_result_handle, y_result_handle, ec_handle, data_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_unmarshal_compressed_ec(env: &VMHooksWrapper, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: i32, length: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.unmarshal_compressed_ec(x_result_handle, y_result_handle, ec_handle, env.convert_mem_ptr(data_offset), env.convert_mem_length(length)))
+    env.vm_hooks.unmarshal_compressed_ec(x_result_handle, y_result_handle, ec_handle, env.convert_mem_ptr(data_offset), env.convert_mem_length(length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_unmarshal_compressed_ec(env: &VMHooksWrapper, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_unmarshal_compressed_ec(x_result_handle, y_result_handle, ec_handle, data_handle))
+    env.vm_hooks.managed_unmarshal_compressed_ec(x_result_handle, y_result_handle, ec_handle, data_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_generate_key_ec(env: &VMHooksWrapper, x_pub_key_handle: i32, y_pub_key_handle: i32, ec_handle: i32, result_offset: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.generate_key_ec(x_pub_key_handle, y_pub_key_handle, ec_handle, env.convert_mem_ptr(result_offset)))
+    env.vm_hooks.generate_key_ec(x_pub_key_handle, y_pub_key_handle, ec_handle, env.convert_mem_ptr(result_offset))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_generate_key_ec(env: &VMHooksWrapper, x_pub_key_handle: i32, y_pub_key_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_generate_key_ec(x_pub_key_handle, y_pub_key_handle, ec_handle, result_handle))
+    env.vm_hooks.managed_generate_key_ec(x_pub_key_handle, y_pub_key_handle, ec_handle, result_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_create_ec(env: &VMHooksWrapper, data_offset: i32, data_length: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.create_ec(env.convert_mem_ptr(data_offset), env.convert_mem_length(data_length)))
+    env.vm_hooks.create_ec(env.convert_mem_ptr(data_offset), env.convert_mem_length(data_length))
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_create_ec(env: &VMHooksWrapper, data_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_create_ec(data_handle))
+    env.vm_hooks.managed_create_ec(data_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_curve_length_ec(env: &VMHooksWrapper, ec_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_curve_length_ec(ec_handle))
+    env.vm_hooks.get_curve_length_ec(ec_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_get_priv_key_byte_length_ec(env: &VMHooksWrapper, ec_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.get_priv_key_byte_length_ec(ec_handle))
+    env.vm_hooks.get_priv_key_byte_length_ec(ec_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_elliptic_curve_get_values(env: &VMHooksWrapper, ec_handle: i32, field_order_handle: i32, base_point_order_handle: i32, eq_constant_handle: i32, x_base_point_handle: i32, y_base_point_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.elliptic_curve_get_values(ec_handle, field_order_handle, base_point_order_handle, eq_constant_handle, x_base_point_handle, y_base_point_handle))
+    env.vm_hooks.elliptic_curve_get_values(ec_handle, field_order_handle, base_point_order_handle, eq_constant_handle, x_base_point_handle, y_base_point_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_verify_secp256r1(env: &VMHooksWrapper, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_verify_secp256r1(key_handle, message_handle, sig_handle))
+    env.vm_hooks.managed_verify_secp256r1(key_handle, message_handle, sig_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_verify_blssignature_share(env: &VMHooksWrapper, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_verify_blssignature_share(key_handle, message_handle, sig_handle))
+    env.vm_hooks.managed_verify_blssignature_share(key_handle, message_handle, sig_handle)
 }
 
 #[rustfmt::skip]
 fn wasmer_import_managed_verify_blsaggregated_signature(env: &VMHooksWrapper, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
-    env.with_vm_hooks(|vh| vh.managed_verify_blsaggregated_signature(key_handle, message_handle, sig_handle))
+    env.vm_hooks.managed_verify_blsaggregated_signature(key_handle, message_handle, sig_handle)
 }
 
 pub fn generate_import_object(store: &Store, env: &VMHooksWrapper) -> ImportObject {

--- a/vm-executor-wasmer/src/wasmer_instance.rs
+++ b/vm-executor-wasmer/src/wasmer_instance.rs
@@ -28,7 +28,7 @@ pub struct WasmerInstance {
 
 impl WasmerInstance {
     pub fn try_new_instance(
-        vm_hooks: Rc<RefCell<Box<dyn VMHooksLegacy>>>,
+        vm_hooks: Rc<Box<dyn VMHooksLegacy>>,
         opcode_cost: Arc<Mutex<OpcodeCost>>,
         wasm_bytes: &[u8],
         compilation_options: &CompilationOptions,
@@ -74,7 +74,7 @@ impl WasmerInstance {
     }
 
     pub fn try_new_instance_from_cache(
-        vm_hooks: Rc<RefCell<Box<dyn VMHooksLegacy>>>,
+        vm_hooks: Rc<Box<dyn VMHooksLegacy>>,
         opcode_cost: Arc<Mutex<OpcodeCost>>,
         cache_bytes: &[u8],
         compilation_options: &CompilationOptions,

--- a/vm-executor-wasmer/src/wasmer_vm_hooks.rs
+++ b/vm-executor-wasmer/src/wasmer_vm_hooks.rs
@@ -21,11 +21,4 @@ impl VMHooksWrapper {
     pub(crate) fn convert_mem_length(&self, raw: i32) -> MemLength {
         raw as MemLength
     }
-
-    pub fn with_vm_hooks<F, R>(&self, f: F) -> R
-    where
-        F: FnOnce(&dyn VMHooksLegacy) -> R,
-    {
-        f(&**self.vm_hooks)
-    }
 }

--- a/vm-executor-wasmer/src/wasmer_vm_hooks.rs
+++ b/vm-executor-wasmer/src/wasmer_vm_hooks.rs
@@ -1,11 +1,11 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Rc;
 
 use multiversx_chain_vm_executor::{MemLength, MemPtr, VMHooksLegacy};
 use wasmer::WasmerEnv;
 
 #[derive(Clone, Debug)]
 pub struct VMHooksWrapper {
-    pub vm_hooks: Rc<RefCell<Box<dyn VMHooksLegacy>>>,
+    pub vm_hooks: Rc<Box<dyn VMHooksLegacy>>,
 }
 
 unsafe impl Send for VMHooksWrapper {}
@@ -24,9 +24,8 @@ impl VMHooksWrapper {
 
     pub fn with_vm_hooks<F, R>(&self, f: F) -> R
     where
-        F: FnOnce(&mut dyn VMHooksLegacy) -> R,
+        F: FnOnce(&dyn VMHooksLegacy) -> R,
     {
-        let mut vm_hooks = self.vm_hooks.borrow_mut();
-        f(&mut **vm_hooks)
+        f(&**self.vm_hooks)
     }
 }

--- a/vm-executor/src/new_traits.rs
+++ b/vm-executor/src/new_traits.rs
@@ -11,5 +11,5 @@ pub use executor_new::Executor;
 pub use instance_new::{Instance, InstanceCallResult};
 pub use instance_state::InstanceState;
 pub use vm_hooks_early_exit::VMHooksEarlyExit;
-pub use vm_hooks_legacy_adapter::VMHooksLegacyAdapter;
+pub use vm_hooks_legacy_adapter::{VMHooksLegacyAdapter, VMHooksSetEarlyExit};
 pub use vm_hooks_new::{VMHooks, VMHooksDefault};

--- a/vm-executor/src/new_traits/vm_hooks_legacy_adapter.rs
+++ b/vm-executor/src/new_traits/vm_hooks_legacy_adapter.rs
@@ -4,1339 +4,1088 @@
 // !!!!!!!!!!!!!!!!!!!!!! AUTO-GENERATED FILE !!!!!!!!!!!!!!!!!!!!!!
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-use std::ffi::c_void;
+use std::{cell::RefCell, ffi::c_void};
 
 use crate::{MemLength, MemPtr, VMHooks, VMHooksEarlyExit, VMHooksLegacy};
+
+/// Allows VM hooks handler to define an early exit method to be used by the VMHooksLegacyAdapter.
+pub trait VMHooksSetEarlyExit: VMHooks {
+    fn set_early_exit(&self, early_exit: VMHooksEarlyExit);
+}
 
 /// Allow conversion from the new VMHooks to the old.
 ///
 /// Will eventually be removed, once everything gets migrated.
-pub trait VMHooksLegacyAdapter: VMHooks {
-    fn set_early_exit(&self, early_exit: VMHooksEarlyExit);
+#[derive(Debug)]
+pub struct VMHooksLegacyAdapter<VH: VMHooksSetEarlyExit> {
+    inner: RefCell<VH>,
+}
 
-    fn unwrap_or_set_breakpoint<R>(&mut self, result: Result<R, VMHooksEarlyExit>) -> R
+impl<VH: VMHooksSetEarlyExit> VMHooksLegacyAdapter<VH> {
+    fn adapt_vm_hooks<F, R>(&self, f: F) -> R
     where
         R: Default,
+        F: FnOnce(&mut dyn VMHooks) -> Result<R, VMHooksEarlyExit>,
     {
+        let mut vm_hooks = self.inner.borrow_mut();
+        let result = f(&mut *vm_hooks);
         result.unwrap_or_else(|early_exit| {
-            self.set_early_exit(early_exit);
+            self.inner.borrow().set_early_exit(early_exit);
             R::default()
         })
     }
 }
 
 #[rustfmt::skip]
-impl<T> VMHooksLegacy for T where T: VMHooksLegacyAdapter {
+impl<VH: VMHooksSetEarlyExit> VMHooksLegacy for VMHooksLegacyAdapter<VH> {
     fn set_vm_hooks_ptr(&mut self, _vm_hooks_ptr: *mut c_void) {
     }
 
-    fn get_gas_left(&mut self) -> i64 {
-        let result = VMHooks::get_gas_left(self);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_gas_left(&self) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_gas_left(inner))
     }
 
-    fn get_sc_address(&mut self, result_offset: MemPtr) {
-        let result = VMHooks::get_sc_address(self, result_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_sc_address(&self, result_offset: MemPtr) {
+        self.adapt_vm_hooks(|inner| VMHooks::get_sc_address(inner, result_offset))
     }
 
-    fn get_owner_address(&mut self, result_offset: MemPtr) {
-        let result = VMHooks::get_owner_address(self, result_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_owner_address(&self, result_offset: MemPtr) {
+        self.adapt_vm_hooks(|inner| VMHooks::get_owner_address(inner, result_offset))
     }
 
-    fn get_shard_of_address(&mut self, address_offset: MemPtr) -> i32 {
-        let result = VMHooks::get_shard_of_address(self, address_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_shard_of_address(&self, address_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_shard_of_address(inner, address_offset))
     }
 
-    fn is_smart_contract(&mut self, address_offset: MemPtr) -> i32 {
-        let result = VMHooks::is_smart_contract(self, address_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn is_smart_contract(&self, address_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::is_smart_contract(inner, address_offset))
     }
 
-    fn signal_error(&mut self, message_offset: MemPtr, message_length: MemLength) {
-        let result = VMHooks::signal_error(self, message_offset, message_length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn signal_error(&self, message_offset: MemPtr, message_length: MemLength) {
+        self.adapt_vm_hooks(|inner| VMHooks::signal_error(inner, message_offset, message_length))
     }
 
-    fn get_external_balance(&mut self, address_offset: MemPtr, result_offset: MemPtr) {
-        let result = VMHooks::get_external_balance(self, address_offset, result_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_external_balance(&self, address_offset: MemPtr, result_offset: MemPtr) {
+        self.adapt_vm_hooks(|inner| VMHooks::get_external_balance(inner, address_offset, result_offset))
     }
 
-    fn get_block_hash(&mut self, nonce: i64, result_offset: MemPtr) -> i32 {
-        let result = VMHooks::get_block_hash(self, nonce, result_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_block_hash(&self, nonce: i64, result_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_block_hash(inner, nonce, result_offset))
     }
 
-    fn get_esdt_balance(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, result_offset: MemPtr) -> i32 {
-        let result = VMHooks::get_esdt_balance(self, address_offset, token_id_offset, token_id_len, nonce, result_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_esdt_balance(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, result_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_esdt_balance(inner, address_offset, token_id_offset, token_id_len, nonce, result_offset))
     }
 
-    fn get_esdt_nft_name_length(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
-        let result = VMHooks::get_esdt_nft_name_length(self, address_offset, token_id_offset, token_id_len, nonce);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_esdt_nft_name_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_esdt_nft_name_length(inner, address_offset, token_id_offset, token_id_len, nonce))
     }
 
-    fn get_esdt_nft_attribute_length(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
-        let result = VMHooks::get_esdt_nft_attribute_length(self, address_offset, token_id_offset, token_id_len, nonce);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_esdt_nft_attribute_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_esdt_nft_attribute_length(inner, address_offset, token_id_offset, token_id_len, nonce))
     }
 
-    fn get_esdt_nft_uri_length(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
-        let result = VMHooks::get_esdt_nft_uri_length(self, address_offset, token_id_offset, token_id_len, nonce);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_esdt_nft_uri_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_esdt_nft_uri_length(inner, address_offset, token_id_offset, token_id_len, nonce))
     }
 
-    fn get_esdt_token_data(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, value_handle: i32, properties_offset: MemPtr, hash_offset: MemPtr, name_offset: MemPtr, attributes_offset: MemPtr, creator_offset: MemPtr, royalties_handle: i32, uris_offset: MemPtr) -> i32 {
-        let result = VMHooks::get_esdt_token_data(self, address_offset, token_id_offset, token_id_len, nonce, value_handle, properties_offset, hash_offset, name_offset, attributes_offset, creator_offset, royalties_handle, uris_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_esdt_token_data(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, value_handle: i32, properties_offset: MemPtr, hash_offset: MemPtr, name_offset: MemPtr, attributes_offset: MemPtr, creator_offset: MemPtr, royalties_handle: i32, uris_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_esdt_token_data(inner, address_offset, token_id_offset, token_id_len, nonce, value_handle, properties_offset, hash_offset, name_offset, attributes_offset, creator_offset, royalties_handle, uris_offset))
     }
 
-    fn get_esdt_local_roles(&mut self, token_id_handle: i32) -> i64 {
-        let result = VMHooks::get_esdt_local_roles(self, token_id_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_esdt_local_roles(&self, token_id_handle: i32) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_esdt_local_roles(inner, token_id_handle))
     }
 
-    fn validate_token_identifier(&mut self, token_id_handle: i32) -> i32 {
-        let result = VMHooks::validate_token_identifier(self, token_id_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn validate_token_identifier(&self, token_id_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::validate_token_identifier(inner, token_id_handle))
     }
 
-    fn transfer_value(&mut self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, length: MemLength) -> i32 {
-        let result = VMHooks::transfer_value(self, dest_offset, value_offset, data_offset, length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn transfer_value(&self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, length: MemLength) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::transfer_value(inner, dest_offset, value_offset, data_offset, length))
     }
 
-    fn transfer_value_execute(&mut self, dest_offset: MemPtr, value_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
-        let result = VMHooks::transfer_value_execute(self, dest_offset, value_offset, gas_limit, function_offset, function_length, num_arguments, arguments_length_offset, data_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn transfer_value_execute(&self, dest_offset: MemPtr, value_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::transfer_value_execute(inner, dest_offset, value_offset, gas_limit, function_offset, function_length, num_arguments, arguments_length_offset, data_offset))
     }
 
-    fn transfer_esdt_execute(&mut self, dest_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, value_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
-        let result = VMHooks::transfer_esdt_execute(self, dest_offset, token_id_offset, token_id_len, value_offset, gas_limit, function_offset, function_length, num_arguments, arguments_length_offset, data_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn transfer_esdt_execute(&self, dest_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, value_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::transfer_esdt_execute(inner, dest_offset, token_id_offset, token_id_len, value_offset, gas_limit, function_offset, function_length, num_arguments, arguments_length_offset, data_offset))
     }
 
-    fn transfer_esdt_nft_execute(&mut self, dest_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, value_offset: MemPtr, nonce: i64, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
-        let result = VMHooks::transfer_esdt_nft_execute(self, dest_offset, token_id_offset, token_id_len, value_offset, nonce, gas_limit, function_offset, function_length, num_arguments, arguments_length_offset, data_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn transfer_esdt_nft_execute(&self, dest_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, value_offset: MemPtr, nonce: i64, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::transfer_esdt_nft_execute(inner, dest_offset, token_id_offset, token_id_len, value_offset, nonce, gas_limit, function_offset, function_length, num_arguments, arguments_length_offset, data_offset))
     }
 
-    fn multi_transfer_esdt_nft_execute(&mut self, dest_offset: MemPtr, num_token_transfers: i32, token_transfers_args_length_offset: MemPtr, token_transfer_data_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
-        let result = VMHooks::multi_transfer_esdt_nft_execute(self, dest_offset, num_token_transfers, token_transfers_args_length_offset, token_transfer_data_offset, gas_limit, function_offset, function_length, num_arguments, arguments_length_offset, data_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn multi_transfer_esdt_nft_execute(&self, dest_offset: MemPtr, num_token_transfers: i32, token_transfers_args_length_offset: MemPtr, token_transfer_data_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::multi_transfer_esdt_nft_execute(inner, dest_offset, num_token_transfers, token_transfers_args_length_offset, token_transfer_data_offset, gas_limit, function_offset, function_length, num_arguments, arguments_length_offset, data_offset))
     }
 
-    fn create_async_call(&mut self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, data_length: MemLength, success_offset: MemPtr, success_length: MemLength, error_offset: MemPtr, error_length: MemLength, gas: i64, extra_gas_for_callback: i64) -> i32 {
-        let result = VMHooks::create_async_call(self, dest_offset, value_offset, data_offset, data_length, success_offset, success_length, error_offset, error_length, gas, extra_gas_for_callback);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn create_async_call(&self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, data_length: MemLength, success_offset: MemPtr, success_length: MemLength, error_offset: MemPtr, error_length: MemLength, gas: i64, extra_gas_for_callback: i64) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::create_async_call(inner, dest_offset, value_offset, data_offset, data_length, success_offset, success_length, error_offset, error_length, gas, extra_gas_for_callback))
     }
 
-    fn set_async_context_callback(&mut self, callback: MemPtr, callback_length: MemLength, data: MemPtr, data_length: MemLength, gas: i64) -> i32 {
-        let result = VMHooks::set_async_context_callback(self, callback, callback_length, data, data_length, gas);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn set_async_context_callback(&self, callback: MemPtr, callback_length: MemLength, data: MemPtr, data_length: MemLength, gas: i64) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::set_async_context_callback(inner, callback, callback_length, data, data_length, gas))
     }
 
-    fn upgrade_contract(&mut self, dest_offset: MemPtr, gas_limit: i64, value_offset: MemPtr, code_offset: MemPtr, code_metadata_offset: MemPtr, length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) {
-        let result = VMHooks::upgrade_contract(self, dest_offset, gas_limit, value_offset, code_offset, code_metadata_offset, length, num_arguments, arguments_length_offset, data_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn upgrade_contract(&self, dest_offset: MemPtr, gas_limit: i64, value_offset: MemPtr, code_offset: MemPtr, code_metadata_offset: MemPtr, length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) {
+        self.adapt_vm_hooks(|inner| VMHooks::upgrade_contract(inner, dest_offset, gas_limit, value_offset, code_offset, code_metadata_offset, length, num_arguments, arguments_length_offset, data_offset))
     }
 
-    fn upgrade_from_source_contract(&mut self, dest_offset: MemPtr, gas_limit: i64, value_offset: MemPtr, source_contract_address_offset: MemPtr, code_metadata_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) {
-        let result = VMHooks::upgrade_from_source_contract(self, dest_offset, gas_limit, value_offset, source_contract_address_offset, code_metadata_offset, num_arguments, arguments_length_offset, data_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn upgrade_from_source_contract(&self, dest_offset: MemPtr, gas_limit: i64, value_offset: MemPtr, source_contract_address_offset: MemPtr, code_metadata_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) {
+        self.adapt_vm_hooks(|inner| VMHooks::upgrade_from_source_contract(inner, dest_offset, gas_limit, value_offset, source_contract_address_offset, code_metadata_offset, num_arguments, arguments_length_offset, data_offset))
     }
 
-    fn delete_contract(&mut self, dest_offset: MemPtr, gas_limit: i64, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) {
-        let result = VMHooks::delete_contract(self, dest_offset, gas_limit, num_arguments, arguments_length_offset, data_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn delete_contract(&self, dest_offset: MemPtr, gas_limit: i64, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) {
+        self.adapt_vm_hooks(|inner| VMHooks::delete_contract(inner, dest_offset, gas_limit, num_arguments, arguments_length_offset, data_offset))
     }
 
-    fn async_call(&mut self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, length: MemLength) {
-        let result = VMHooks::async_call(self, dest_offset, value_offset, data_offset, length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn async_call(&self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, length: MemLength) {
+        self.adapt_vm_hooks(|inner| VMHooks::async_call(inner, dest_offset, value_offset, data_offset, length))
     }
 
-    fn get_argument_length(&mut self, id: i32) -> i32 {
-        let result = VMHooks::get_argument_length(self, id);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_argument_length(&self, id: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_argument_length(inner, id))
     }
 
-    fn get_argument(&mut self, id: i32, arg_offset: MemPtr) -> i32 {
-        let result = VMHooks::get_argument(self, id, arg_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_argument(&self, id: i32, arg_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_argument(inner, id, arg_offset))
     }
 
-    fn get_function(&mut self, function_offset: MemPtr) -> i32 {
-        let result = VMHooks::get_function(self, function_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_function(&self, function_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_function(inner, function_offset))
     }
 
-    fn get_num_arguments(&mut self) -> i32 {
-        let result = VMHooks::get_num_arguments(self);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_num_arguments(&self) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_num_arguments(inner))
     }
 
-    fn storage_store(&mut self, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr, data_length: MemLength) -> i32 {
-        let result = VMHooks::storage_store(self, key_offset, key_length, data_offset, data_length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn storage_store(&self, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr, data_length: MemLength) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::storage_store(inner, key_offset, key_length, data_offset, data_length))
     }
 
-    fn storage_load_length(&mut self, key_offset: MemPtr, key_length: MemLength) -> i32 {
-        let result = VMHooks::storage_load_length(self, key_offset, key_length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn storage_load_length(&self, key_offset: MemPtr, key_length: MemLength) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::storage_load_length(inner, key_offset, key_length))
     }
 
-    fn storage_load_from_address(&mut self, address_offset: MemPtr, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr) -> i32 {
-        let result = VMHooks::storage_load_from_address(self, address_offset, key_offset, key_length, data_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn storage_load_from_address(&self, address_offset: MemPtr, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::storage_load_from_address(inner, address_offset, key_offset, key_length, data_offset))
     }
 
-    fn storage_load(&mut self, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr) -> i32 {
-        let result = VMHooks::storage_load(self, key_offset, key_length, data_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn storage_load(&self, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::storage_load(inner, key_offset, key_length, data_offset))
     }
 
-    fn set_storage_lock(&mut self, key_offset: MemPtr, key_length: MemLength, lock_timestamp: i64) -> i32 {
-        let result = VMHooks::set_storage_lock(self, key_offset, key_length, lock_timestamp);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn set_storage_lock(&self, key_offset: MemPtr, key_length: MemLength, lock_timestamp: i64) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::set_storage_lock(inner, key_offset, key_length, lock_timestamp))
     }
 
-    fn get_storage_lock(&mut self, key_offset: MemPtr, key_length: MemLength) -> i64 {
-        let result = VMHooks::get_storage_lock(self, key_offset, key_length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_storage_lock(&self, key_offset: MemPtr, key_length: MemLength) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_storage_lock(inner, key_offset, key_length))
     }
 
-    fn is_storage_locked(&mut self, key_offset: MemPtr, key_length: MemLength) -> i32 {
-        let result = VMHooks::is_storage_locked(self, key_offset, key_length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn is_storage_locked(&self, key_offset: MemPtr, key_length: MemLength) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::is_storage_locked(inner, key_offset, key_length))
     }
 
-    fn clear_storage_lock(&mut self, key_offset: MemPtr, key_length: MemLength) -> i32 {
-        let result = VMHooks::clear_storage_lock(self, key_offset, key_length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn clear_storage_lock(&self, key_offset: MemPtr, key_length: MemLength) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::clear_storage_lock(inner, key_offset, key_length))
     }
 
-    fn get_caller(&mut self, result_offset: MemPtr) {
-        let result = VMHooks::get_caller(self, result_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_caller(&self, result_offset: MemPtr) {
+        self.adapt_vm_hooks(|inner| VMHooks::get_caller(inner, result_offset))
     }
 
-    fn check_no_payment(&mut self) {
-        let result = VMHooks::check_no_payment(self);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn check_no_payment(&self) {
+        self.adapt_vm_hooks(|inner| VMHooks::check_no_payment(inner))
     }
 
-    fn get_call_value(&mut self, result_offset: MemPtr) -> i32 {
-        let result = VMHooks::get_call_value(self, result_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_call_value(&self, result_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_call_value(inner, result_offset))
     }
 
-    fn get_esdt_value(&mut self, result_offset: MemPtr) -> i32 {
-        let result = VMHooks::get_esdt_value(self, result_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_esdt_value(&self, result_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_esdt_value(inner, result_offset))
     }
 
-    fn get_esdt_value_by_index(&mut self, result_offset: MemPtr, index: i32) -> i32 {
-        let result = VMHooks::get_esdt_value_by_index(self, result_offset, index);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_esdt_value_by_index(&self, result_offset: MemPtr, index: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_esdt_value_by_index(inner, result_offset, index))
     }
 
-    fn get_esdt_token_name(&mut self, result_offset: MemPtr) -> i32 {
-        let result = VMHooks::get_esdt_token_name(self, result_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_esdt_token_name(&self, result_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_esdt_token_name(inner, result_offset))
     }
 
-    fn get_esdt_token_name_by_index(&mut self, result_offset: MemPtr, index: i32) -> i32 {
-        let result = VMHooks::get_esdt_token_name_by_index(self, result_offset, index);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_esdt_token_name_by_index(&self, result_offset: MemPtr, index: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_esdt_token_name_by_index(inner, result_offset, index))
     }
 
-    fn get_esdt_token_nonce(&mut self) -> i64 {
-        let result = VMHooks::get_esdt_token_nonce(self);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_esdt_token_nonce(&self) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_esdt_token_nonce(inner))
     }
 
-    fn get_esdt_token_nonce_by_index(&mut self, index: i32) -> i64 {
-        let result = VMHooks::get_esdt_token_nonce_by_index(self, index);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_esdt_token_nonce_by_index(&self, index: i32) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_esdt_token_nonce_by_index(inner, index))
     }
 
-    fn get_current_esdt_nft_nonce(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength) -> i64 {
-        let result = VMHooks::get_current_esdt_nft_nonce(self, address_offset, token_id_offset, token_id_len);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_current_esdt_nft_nonce(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_current_esdt_nft_nonce(inner, address_offset, token_id_offset, token_id_len))
     }
 
-    fn get_esdt_token_type(&mut self) -> i32 {
-        let result = VMHooks::get_esdt_token_type(self);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_esdt_token_type(&self) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_esdt_token_type(inner))
     }
 
-    fn get_esdt_token_type_by_index(&mut self, index: i32) -> i32 {
-        let result = VMHooks::get_esdt_token_type_by_index(self, index);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_esdt_token_type_by_index(&self, index: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_esdt_token_type_by_index(inner, index))
     }
 
-    fn get_num_esdt_transfers(&mut self) -> i32 {
-        let result = VMHooks::get_num_esdt_transfers(self);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_num_esdt_transfers(&self) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_num_esdt_transfers(inner))
     }
 
-    fn get_call_value_token_name(&mut self, call_value_offset: MemPtr, token_name_offset: MemPtr) -> i32 {
-        let result = VMHooks::get_call_value_token_name(self, call_value_offset, token_name_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_call_value_token_name(&self, call_value_offset: MemPtr, token_name_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_call_value_token_name(inner, call_value_offset, token_name_offset))
     }
 
-    fn get_call_value_token_name_by_index(&mut self, call_value_offset: MemPtr, token_name_offset: MemPtr, index: i32) -> i32 {
-        let result = VMHooks::get_call_value_token_name_by_index(self, call_value_offset, token_name_offset, index);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_call_value_token_name_by_index(&self, call_value_offset: MemPtr, token_name_offset: MemPtr, index: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_call_value_token_name_by_index(inner, call_value_offset, token_name_offset, index))
     }
 
-    fn is_reserved_function_name(&mut self, name_handle: i32) -> i32 {
-        let result = VMHooks::is_reserved_function_name(self, name_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn is_reserved_function_name(&self, name_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::is_reserved_function_name(inner, name_handle))
     }
 
-    fn write_log(&mut self, data_pointer: MemPtr, data_length: MemLength, topic_ptr: MemPtr, num_topics: i32) {
-        let result = VMHooks::write_log(self, data_pointer, data_length, topic_ptr, num_topics);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn write_log(&self, data_pointer: MemPtr, data_length: MemLength, topic_ptr: MemPtr, num_topics: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::write_log(inner, data_pointer, data_length, topic_ptr, num_topics))
     }
 
-    fn write_event_log(&mut self, num_topics: i32, topic_lengths_offset: MemPtr, topic_offset: MemPtr, data_offset: MemPtr, data_length: MemLength) {
-        let result = VMHooks::write_event_log(self, num_topics, topic_lengths_offset, topic_offset, data_offset, data_length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn write_event_log(&self, num_topics: i32, topic_lengths_offset: MemPtr, topic_offset: MemPtr, data_offset: MemPtr, data_length: MemLength) {
+        self.adapt_vm_hooks(|inner| VMHooks::write_event_log(inner, num_topics, topic_lengths_offset, topic_offset, data_offset, data_length))
     }
 
-    fn get_block_timestamp(&mut self) -> i64 {
-        let result = VMHooks::get_block_timestamp(self);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_block_timestamp(&self) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_block_timestamp(inner))
     }
 
-    fn get_block_nonce(&mut self) -> i64 {
-        let result = VMHooks::get_block_nonce(self);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_block_nonce(&self) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_block_nonce(inner))
     }
 
-    fn get_block_round(&mut self) -> i64 {
-        let result = VMHooks::get_block_round(self);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_block_round(&self) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_block_round(inner))
     }
 
-    fn get_block_epoch(&mut self) -> i64 {
-        let result = VMHooks::get_block_epoch(self);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_block_epoch(&self) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_block_epoch(inner))
     }
 
-    fn get_block_random_seed(&mut self, pointer: MemPtr) {
-        let result = VMHooks::get_block_random_seed(self, pointer);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_block_random_seed(&self, pointer: MemPtr) {
+        self.adapt_vm_hooks(|inner| VMHooks::get_block_random_seed(inner, pointer))
     }
 
-    fn get_state_root_hash(&mut self, pointer: MemPtr) {
-        let result = VMHooks::get_state_root_hash(self, pointer);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_state_root_hash(&self, pointer: MemPtr) {
+        self.adapt_vm_hooks(|inner| VMHooks::get_state_root_hash(inner, pointer))
     }
 
-    fn get_prev_block_timestamp(&mut self) -> i64 {
-        let result = VMHooks::get_prev_block_timestamp(self);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_prev_block_timestamp(&self) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_prev_block_timestamp(inner))
     }
 
-    fn get_prev_block_nonce(&mut self) -> i64 {
-        let result = VMHooks::get_prev_block_nonce(self);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_prev_block_nonce(&self) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_prev_block_nonce(inner))
     }
 
-    fn get_prev_block_round(&mut self) -> i64 {
-        let result = VMHooks::get_prev_block_round(self);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_prev_block_round(&self) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_prev_block_round(inner))
     }
 
-    fn get_prev_block_epoch(&mut self) -> i64 {
-        let result = VMHooks::get_prev_block_epoch(self);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_prev_block_epoch(&self) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_prev_block_epoch(inner))
     }
 
-    fn get_prev_block_random_seed(&mut self, pointer: MemPtr) {
-        let result = VMHooks::get_prev_block_random_seed(self, pointer);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_prev_block_random_seed(&self, pointer: MemPtr) {
+        self.adapt_vm_hooks(|inner| VMHooks::get_prev_block_random_seed(inner, pointer))
     }
 
-    fn finish(&mut self, pointer: MemPtr, length: MemLength) {
-        let result = VMHooks::finish(self, pointer, length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn finish(&self, pointer: MemPtr, length: MemLength) {
+        self.adapt_vm_hooks(|inner| VMHooks::finish(inner, pointer, length))
     }
 
-    fn execute_on_same_context(&mut self, gas_limit: i64, address_offset: MemPtr, value_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
-        let result = VMHooks::execute_on_same_context(self, gas_limit, address_offset, value_offset, function_offset, function_length, num_arguments, arguments_length_offset, data_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn execute_on_same_context(&self, gas_limit: i64, address_offset: MemPtr, value_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::execute_on_same_context(inner, gas_limit, address_offset, value_offset, function_offset, function_length, num_arguments, arguments_length_offset, data_offset))
     }
 
-    fn execute_on_dest_context(&mut self, gas_limit: i64, address_offset: MemPtr, value_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
-        let result = VMHooks::execute_on_dest_context(self, gas_limit, address_offset, value_offset, function_offset, function_length, num_arguments, arguments_length_offset, data_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn execute_on_dest_context(&self, gas_limit: i64, address_offset: MemPtr, value_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::execute_on_dest_context(inner, gas_limit, address_offset, value_offset, function_offset, function_length, num_arguments, arguments_length_offset, data_offset))
     }
 
-    fn execute_read_only(&mut self, gas_limit: i64, address_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
-        let result = VMHooks::execute_read_only(self, gas_limit, address_offset, function_offset, function_length, num_arguments, arguments_length_offset, data_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn execute_read_only(&self, gas_limit: i64, address_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::execute_read_only(inner, gas_limit, address_offset, function_offset, function_length, num_arguments, arguments_length_offset, data_offset))
     }
 
-    fn create_contract(&mut self, gas_limit: i64, value_offset: MemPtr, code_offset: MemPtr, code_metadata_offset: MemPtr, length: MemLength, result_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
-        let result = VMHooks::create_contract(self, gas_limit, value_offset, code_offset, code_metadata_offset, length, result_offset, num_arguments, arguments_length_offset, data_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn create_contract(&self, gas_limit: i64, value_offset: MemPtr, code_offset: MemPtr, code_metadata_offset: MemPtr, length: MemLength, result_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::create_contract(inner, gas_limit, value_offset, code_offset, code_metadata_offset, length, result_offset, num_arguments, arguments_length_offset, data_offset))
     }
 
-    fn deploy_from_source_contract(&mut self, gas_limit: i64, value_offset: MemPtr, source_contract_address_offset: MemPtr, code_metadata_offset: MemPtr, result_address_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
-        let result = VMHooks::deploy_from_source_contract(self, gas_limit, value_offset, source_contract_address_offset, code_metadata_offset, result_address_offset, num_arguments, arguments_length_offset, data_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn deploy_from_source_contract(&self, gas_limit: i64, value_offset: MemPtr, source_contract_address_offset: MemPtr, code_metadata_offset: MemPtr, result_address_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::deploy_from_source_contract(inner, gas_limit, value_offset, source_contract_address_offset, code_metadata_offset, result_address_offset, num_arguments, arguments_length_offset, data_offset))
     }
 
-    fn get_num_return_data(&mut self) -> i32 {
-        let result = VMHooks::get_num_return_data(self);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_num_return_data(&self) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_num_return_data(inner))
     }
 
-    fn get_return_data_size(&mut self, result_id: i32) -> i32 {
-        let result = VMHooks::get_return_data_size(self, result_id);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_return_data_size(&self, result_id: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_return_data_size(inner, result_id))
     }
 
-    fn get_return_data(&mut self, result_id: i32, data_offset: MemPtr) -> i32 {
-        let result = VMHooks::get_return_data(self, result_id, data_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_return_data(&self, result_id: i32, data_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_return_data(inner, result_id, data_offset))
     }
 
-    fn clean_return_data(&mut self) {
-        let result = VMHooks::clean_return_data(self);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn clean_return_data(&self) {
+        self.adapt_vm_hooks(|inner| VMHooks::clean_return_data(inner))
     }
 
-    fn delete_from_return_data(&mut self, result_id: i32) {
-        let result = VMHooks::delete_from_return_data(self, result_id);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn delete_from_return_data(&self, result_id: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::delete_from_return_data(inner, result_id))
     }
 
-    fn get_original_tx_hash(&mut self, data_offset: MemPtr) {
-        let result = VMHooks::get_original_tx_hash(self, data_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_original_tx_hash(&self, data_offset: MemPtr) {
+        self.adapt_vm_hooks(|inner| VMHooks::get_original_tx_hash(inner, data_offset))
     }
 
-    fn get_current_tx_hash(&mut self, data_offset: MemPtr) {
-        let result = VMHooks::get_current_tx_hash(self, data_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_current_tx_hash(&self, data_offset: MemPtr) {
+        self.adapt_vm_hooks(|inner| VMHooks::get_current_tx_hash(inner, data_offset))
     }
 
-    fn get_prev_tx_hash(&mut self, data_offset: MemPtr) {
-        let result = VMHooks::get_prev_tx_hash(self, data_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_prev_tx_hash(&self, data_offset: MemPtr) {
+        self.adapt_vm_hooks(|inner| VMHooks::get_prev_tx_hash(inner, data_offset))
     }
 
-    fn managed_sc_address(&mut self, destination_handle: i32) {
-        let result = VMHooks::managed_sc_address(self, destination_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_sc_address(&self, destination_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_sc_address(inner, destination_handle))
     }
 
-    fn managed_owner_address(&mut self, destination_handle: i32) {
-        let result = VMHooks::managed_owner_address(self, destination_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_owner_address(&self, destination_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_owner_address(inner, destination_handle))
     }
 
-    fn managed_caller(&mut self, destination_handle: i32) {
-        let result = VMHooks::managed_caller(self, destination_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_caller(&self, destination_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_caller(inner, destination_handle))
     }
 
-    fn managed_get_original_caller_addr(&mut self, destination_handle: i32) {
-        let result = VMHooks::managed_get_original_caller_addr(self, destination_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_get_original_caller_addr(&self, destination_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_get_original_caller_addr(inner, destination_handle))
     }
 
-    fn managed_get_relayer_addr(&mut self, destination_handle: i32) {
-        let result = VMHooks::managed_get_relayer_addr(self, destination_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_get_relayer_addr(&self, destination_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_get_relayer_addr(inner, destination_handle))
     }
 
-    fn managed_signal_error(&mut self, err_handle: i32) {
-        let result = VMHooks::managed_signal_error(self, err_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_signal_error(&self, err_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_signal_error(inner, err_handle))
     }
 
-    fn managed_write_log(&mut self, topics_handle: i32, data_handle: i32) {
-        let result = VMHooks::managed_write_log(self, topics_handle, data_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_write_log(&self, topics_handle: i32, data_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_write_log(inner, topics_handle, data_handle))
     }
 
-    fn managed_get_original_tx_hash(&mut self, result_handle: i32) {
-        let result = VMHooks::managed_get_original_tx_hash(self, result_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_get_original_tx_hash(&self, result_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_get_original_tx_hash(inner, result_handle))
     }
 
-    fn managed_get_state_root_hash(&mut self, result_handle: i32) {
-        let result = VMHooks::managed_get_state_root_hash(self, result_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_get_state_root_hash(&self, result_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_get_state_root_hash(inner, result_handle))
     }
 
-    fn managed_get_block_random_seed(&mut self, result_handle: i32) {
-        let result = VMHooks::managed_get_block_random_seed(self, result_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_get_block_random_seed(&self, result_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_get_block_random_seed(inner, result_handle))
     }
 
-    fn managed_get_prev_block_random_seed(&mut self, result_handle: i32) {
-        let result = VMHooks::managed_get_prev_block_random_seed(self, result_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_get_prev_block_random_seed(&self, result_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_get_prev_block_random_seed(inner, result_handle))
     }
 
-    fn managed_get_return_data(&mut self, result_id: i32, result_handle: i32) {
-        let result = VMHooks::managed_get_return_data(self, result_id, result_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_get_return_data(&self, result_id: i32, result_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_get_return_data(inner, result_id, result_handle))
     }
 
-    fn managed_get_multi_esdt_call_value(&mut self, multi_call_value_handle: i32) {
-        let result = VMHooks::managed_get_multi_esdt_call_value(self, multi_call_value_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_get_multi_esdt_call_value(&self, multi_call_value_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_get_multi_esdt_call_value(inner, multi_call_value_handle))
     }
 
-    fn managed_get_back_transfers(&mut self, esdt_transfers_value_handle: i32, egld_value_handle: i32) {
-        let result = VMHooks::managed_get_back_transfers(self, esdt_transfers_value_handle, egld_value_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_get_back_transfers(&self, esdt_transfers_value_handle: i32, egld_value_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_get_back_transfers(inner, esdt_transfers_value_handle, egld_value_handle))
     }
 
-    fn managed_get_esdt_balance(&mut self, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32) {
-        let result = VMHooks::managed_get_esdt_balance(self, address_handle, token_id_handle, nonce, value_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_get_esdt_balance(&self, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_get_esdt_balance(inner, address_handle, token_id_handle, nonce, value_handle))
     }
 
-    fn managed_get_esdt_token_data(&mut self, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32, properties_handle: i32, hash_handle: i32, name_handle: i32, attributes_handle: i32, creator_handle: i32, royalties_handle: i32, uris_handle: i32) {
-        let result = VMHooks::managed_get_esdt_token_data(self, address_handle, token_id_handle, nonce, value_handle, properties_handle, hash_handle, name_handle, attributes_handle, creator_handle, royalties_handle, uris_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_get_esdt_token_data(&self, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32, properties_handle: i32, hash_handle: i32, name_handle: i32, attributes_handle: i32, creator_handle: i32, royalties_handle: i32, uris_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_get_esdt_token_data(inner, address_handle, token_id_handle, nonce, value_handle, properties_handle, hash_handle, name_handle, attributes_handle, creator_handle, royalties_handle, uris_handle))
     }
 
-    fn managed_async_call(&mut self, dest_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32) {
-        let result = VMHooks::managed_async_call(self, dest_handle, value_handle, function_handle, arguments_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_async_call(&self, dest_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_async_call(inner, dest_handle, value_handle, function_handle, arguments_handle))
     }
 
-    fn managed_create_async_call(&mut self, dest_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, success_offset: MemPtr, success_length: MemLength, error_offset: MemPtr, error_length: MemLength, gas: i64, extra_gas_for_callback: i64, callback_closure_handle: i32) -> i32 {
-        let result = VMHooks::managed_create_async_call(self, dest_handle, value_handle, function_handle, arguments_handle, success_offset, success_length, error_offset, error_length, gas, extra_gas_for_callback, callback_closure_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_create_async_call(&self, dest_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, success_offset: MemPtr, success_length: MemLength, error_offset: MemPtr, error_length: MemLength, gas: i64, extra_gas_for_callback: i64, callback_closure_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_create_async_call(inner, dest_handle, value_handle, function_handle, arguments_handle, success_offset, success_length, error_offset, error_length, gas, extra_gas_for_callback, callback_closure_handle))
     }
 
-    fn managed_get_callback_closure(&mut self, callback_closure_handle: i32) {
-        let result = VMHooks::managed_get_callback_closure(self, callback_closure_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_get_callback_closure(&self, callback_closure_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_get_callback_closure(inner, callback_closure_handle))
     }
 
-    fn managed_upgrade_from_source_contract(&mut self, dest_handle: i32, gas: i64, value_handle: i32, address_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_handle: i32) {
-        let result = VMHooks::managed_upgrade_from_source_contract(self, dest_handle, gas, value_handle, address_handle, code_metadata_handle, arguments_handle, result_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_upgrade_from_source_contract(&self, dest_handle: i32, gas: i64, value_handle: i32, address_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_upgrade_from_source_contract(inner, dest_handle, gas, value_handle, address_handle, code_metadata_handle, arguments_handle, result_handle))
     }
 
-    fn managed_upgrade_contract(&mut self, dest_handle: i32, gas: i64, value_handle: i32, code_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_handle: i32) {
-        let result = VMHooks::managed_upgrade_contract(self, dest_handle, gas, value_handle, code_handle, code_metadata_handle, arguments_handle, result_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_upgrade_contract(&self, dest_handle: i32, gas: i64, value_handle: i32, code_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_upgrade_contract(inner, dest_handle, gas, value_handle, code_handle, code_metadata_handle, arguments_handle, result_handle))
     }
 
-    fn managed_delete_contract(&mut self, dest_handle: i32, gas_limit: i64, arguments_handle: i32) {
-        let result = VMHooks::managed_delete_contract(self, dest_handle, gas_limit, arguments_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_delete_contract(&self, dest_handle: i32, gas_limit: i64, arguments_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_delete_contract(inner, dest_handle, gas_limit, arguments_handle))
     }
 
-    fn managed_deploy_from_source_contract(&mut self, gas: i64, value_handle: i32, address_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_address_handle: i32, result_handle: i32) -> i32 {
-        let result = VMHooks::managed_deploy_from_source_contract(self, gas, value_handle, address_handle, code_metadata_handle, arguments_handle, result_address_handle, result_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_deploy_from_source_contract(&self, gas: i64, value_handle: i32, address_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_address_handle: i32, result_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_deploy_from_source_contract(inner, gas, value_handle, address_handle, code_metadata_handle, arguments_handle, result_address_handle, result_handle))
     }
 
-    fn managed_create_contract(&mut self, gas: i64, value_handle: i32, code_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_address_handle: i32, result_handle: i32) -> i32 {
-        let result = VMHooks::managed_create_contract(self, gas, value_handle, code_handle, code_metadata_handle, arguments_handle, result_address_handle, result_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_create_contract(&self, gas: i64, value_handle: i32, code_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_address_handle: i32, result_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_create_contract(inner, gas, value_handle, code_handle, code_metadata_handle, arguments_handle, result_address_handle, result_handle))
     }
 
-    fn managed_execute_read_only(&mut self, gas: i64, address_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
-        let result = VMHooks::managed_execute_read_only(self, gas, address_handle, function_handle, arguments_handle, result_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_execute_read_only(&self, gas: i64, address_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_execute_read_only(inner, gas, address_handle, function_handle, arguments_handle, result_handle))
     }
 
-    fn managed_execute_on_same_context(&mut self, gas: i64, address_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
-        let result = VMHooks::managed_execute_on_same_context(self, gas, address_handle, value_handle, function_handle, arguments_handle, result_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_execute_on_same_context(&self, gas: i64, address_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_execute_on_same_context(inner, gas, address_handle, value_handle, function_handle, arguments_handle, result_handle))
     }
 
-    fn managed_execute_on_dest_context(&mut self, gas: i64, address_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
-        let result = VMHooks::managed_execute_on_dest_context(self, gas, address_handle, value_handle, function_handle, arguments_handle, result_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_execute_on_dest_context(&self, gas: i64, address_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_execute_on_dest_context(inner, gas, address_handle, value_handle, function_handle, arguments_handle, result_handle))
     }
 
-    fn managed_multi_transfer_esdt_nft_execute(&mut self, dst_handle: i32, token_transfers_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
-        let result = VMHooks::managed_multi_transfer_esdt_nft_execute(self, dst_handle, token_transfers_handle, gas_limit, function_handle, arguments_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_multi_transfer_esdt_nft_execute(&self, dst_handle: i32, token_transfers_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_multi_transfer_esdt_nft_execute(inner, dst_handle, token_transfers_handle, gas_limit, function_handle, arguments_handle))
     }
 
-    fn managed_multi_transfer_esdt_nft_execute_by_user(&mut self, user_handle: i32, dst_handle: i32, token_transfers_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
-        let result = VMHooks::managed_multi_transfer_esdt_nft_execute_by_user(self, user_handle, dst_handle, token_transfers_handle, gas_limit, function_handle, arguments_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_multi_transfer_esdt_nft_execute_by_user(&self, user_handle: i32, dst_handle: i32, token_transfers_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_multi_transfer_esdt_nft_execute_by_user(inner, user_handle, dst_handle, token_transfers_handle, gas_limit, function_handle, arguments_handle))
     }
 
-    fn managed_transfer_value_execute(&mut self, dst_handle: i32, value_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
-        let result = VMHooks::managed_transfer_value_execute(self, dst_handle, value_handle, gas_limit, function_handle, arguments_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_transfer_value_execute(&self, dst_handle: i32, value_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_transfer_value_execute(inner, dst_handle, value_handle, gas_limit, function_handle, arguments_handle))
     }
 
-    fn managed_is_esdt_frozen(&mut self, address_handle: i32, token_id_handle: i32, nonce: i64) -> i32 {
-        let result = VMHooks::managed_is_esdt_frozen(self, address_handle, token_id_handle, nonce);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_is_esdt_frozen(&self, address_handle: i32, token_id_handle: i32, nonce: i64) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_is_esdt_frozen(inner, address_handle, token_id_handle, nonce))
     }
 
-    fn managed_is_esdt_limited_transfer(&mut self, token_id_handle: i32) -> i32 {
-        let result = VMHooks::managed_is_esdt_limited_transfer(self, token_id_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_is_esdt_limited_transfer(&self, token_id_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_is_esdt_limited_transfer(inner, token_id_handle))
     }
 
-    fn managed_is_esdt_paused(&mut self, token_id_handle: i32) -> i32 {
-        let result = VMHooks::managed_is_esdt_paused(self, token_id_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_is_esdt_paused(&self, token_id_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_is_esdt_paused(inner, token_id_handle))
     }
 
-    fn managed_buffer_to_hex(&mut self, source_handle: i32, dest_handle: i32) {
-        let result = VMHooks::managed_buffer_to_hex(self, source_handle, dest_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_buffer_to_hex(&self, source_handle: i32, dest_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_buffer_to_hex(inner, source_handle, dest_handle))
     }
 
-    fn managed_get_code_metadata(&mut self, address_handle: i32, response_handle: i32) {
-        let result = VMHooks::managed_get_code_metadata(self, address_handle, response_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_get_code_metadata(&self, address_handle: i32, response_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_get_code_metadata(inner, address_handle, response_handle))
     }
 
-    fn managed_is_builtin_function(&mut self, function_name_handle: i32) -> i32 {
-        let result = VMHooks::managed_is_builtin_function(self, function_name_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_is_builtin_function(&self, function_name_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_is_builtin_function(inner, function_name_handle))
     }
 
-    fn big_float_new_from_parts(&mut self, integral_part: i32, fractional_part: i32, exponent: i32) -> i32 {
-        let result = VMHooks::big_float_new_from_parts(self, integral_part, fractional_part, exponent);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_new_from_parts(&self, integral_part: i32, fractional_part: i32, exponent: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_new_from_parts(inner, integral_part, fractional_part, exponent))
     }
 
-    fn big_float_new_from_frac(&mut self, numerator: i64, denominator: i64) -> i32 {
-        let result = VMHooks::big_float_new_from_frac(self, numerator, denominator);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_new_from_frac(&self, numerator: i64, denominator: i64) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_new_from_frac(inner, numerator, denominator))
     }
 
-    fn big_float_new_from_sci(&mut self, significand: i64, exponent: i64) -> i32 {
-        let result = VMHooks::big_float_new_from_sci(self, significand, exponent);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_new_from_sci(&self, significand: i64, exponent: i64) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_new_from_sci(inner, significand, exponent))
     }
 
-    fn big_float_add(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-        let result = VMHooks::big_float_add(self, destination_handle, op1_handle, op2_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_add(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_add(inner, destination_handle, op1_handle, op2_handle))
     }
 
-    fn big_float_sub(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-        let result = VMHooks::big_float_sub(self, destination_handle, op1_handle, op2_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_sub(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_sub(inner, destination_handle, op1_handle, op2_handle))
     }
 
-    fn big_float_mul(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-        let result = VMHooks::big_float_mul(self, destination_handle, op1_handle, op2_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_mul(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_mul(inner, destination_handle, op1_handle, op2_handle))
     }
 
-    fn big_float_div(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-        let result = VMHooks::big_float_div(self, destination_handle, op1_handle, op2_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_div(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_div(inner, destination_handle, op1_handle, op2_handle))
     }
 
-    fn big_float_neg(&mut self, destination_handle: i32, op_handle: i32) {
-        let result = VMHooks::big_float_neg(self, destination_handle, op_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_neg(&self, destination_handle: i32, op_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_neg(inner, destination_handle, op_handle))
     }
 
-    fn big_float_clone(&mut self, destination_handle: i32, op_handle: i32) {
-        let result = VMHooks::big_float_clone(self, destination_handle, op_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_clone(&self, destination_handle: i32, op_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_clone(inner, destination_handle, op_handle))
     }
 
-    fn big_float_cmp(&mut self, op1_handle: i32, op2_handle: i32) -> i32 {
-        let result = VMHooks::big_float_cmp(self, op1_handle, op2_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_cmp(&self, op1_handle: i32, op2_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_cmp(inner, op1_handle, op2_handle))
     }
 
-    fn big_float_abs(&mut self, destination_handle: i32, op_handle: i32) {
-        let result = VMHooks::big_float_abs(self, destination_handle, op_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_abs(&self, destination_handle: i32, op_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_abs(inner, destination_handle, op_handle))
     }
 
-    fn big_float_sign(&mut self, op_handle: i32) -> i32 {
-        let result = VMHooks::big_float_sign(self, op_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_sign(&self, op_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_sign(inner, op_handle))
     }
 
-    fn big_float_sqrt(&mut self, destination_handle: i32, op_handle: i32) {
-        let result = VMHooks::big_float_sqrt(self, destination_handle, op_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_sqrt(&self, destination_handle: i32, op_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_sqrt(inner, destination_handle, op_handle))
     }
 
-    fn big_float_pow(&mut self, destination_handle: i32, op_handle: i32, exponent: i32) {
-        let result = VMHooks::big_float_pow(self, destination_handle, op_handle, exponent);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_pow(&self, destination_handle: i32, op_handle: i32, exponent: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_pow(inner, destination_handle, op_handle, exponent))
     }
 
-    fn big_float_floor(&mut self, dest_big_int_handle: i32, op_handle: i32) {
-        let result = VMHooks::big_float_floor(self, dest_big_int_handle, op_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_floor(&self, dest_big_int_handle: i32, op_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_floor(inner, dest_big_int_handle, op_handle))
     }
 
-    fn big_float_ceil(&mut self, dest_big_int_handle: i32, op_handle: i32) {
-        let result = VMHooks::big_float_ceil(self, dest_big_int_handle, op_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_ceil(&self, dest_big_int_handle: i32, op_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_ceil(inner, dest_big_int_handle, op_handle))
     }
 
-    fn big_float_truncate(&mut self, dest_big_int_handle: i32, op_handle: i32) {
-        let result = VMHooks::big_float_truncate(self, dest_big_int_handle, op_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_truncate(&self, dest_big_int_handle: i32, op_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_truncate(inner, dest_big_int_handle, op_handle))
     }
 
-    fn big_float_set_int64(&mut self, destination_handle: i32, value: i64) {
-        let result = VMHooks::big_float_set_int64(self, destination_handle, value);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_set_int64(&self, destination_handle: i32, value: i64) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_set_int64(inner, destination_handle, value))
     }
 
-    fn big_float_is_int(&mut self, op_handle: i32) -> i32 {
-        let result = VMHooks::big_float_is_int(self, op_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_is_int(&self, op_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_is_int(inner, op_handle))
     }
 
-    fn big_float_set_big_int(&mut self, destination_handle: i32, big_int_handle: i32) {
-        let result = VMHooks::big_float_set_big_int(self, destination_handle, big_int_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_set_big_int(&self, destination_handle: i32, big_int_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_set_big_int(inner, destination_handle, big_int_handle))
     }
 
-    fn big_float_get_const_pi(&mut self, destination_handle: i32) {
-        let result = VMHooks::big_float_get_const_pi(self, destination_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_get_const_pi(&self, destination_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_get_const_pi(inner, destination_handle))
     }
 
-    fn big_float_get_const_e(&mut self, destination_handle: i32) {
-        let result = VMHooks::big_float_get_const_e(self, destination_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_float_get_const_e(&self, destination_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_float_get_const_e(inner, destination_handle))
     }
 
-    fn big_int_get_unsigned_argument(&mut self, id: i32, destination_handle: i32) {
-        let result = VMHooks::big_int_get_unsigned_argument(self, id, destination_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_get_unsigned_argument(&self, id: i32, destination_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_get_unsigned_argument(inner, id, destination_handle))
     }
 
-    fn big_int_get_signed_argument(&mut self, id: i32, destination_handle: i32) {
-        let result = VMHooks::big_int_get_signed_argument(self, id, destination_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_get_signed_argument(&self, id: i32, destination_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_get_signed_argument(inner, id, destination_handle))
     }
 
-    fn big_int_storage_store_unsigned(&mut self, key_offset: MemPtr, key_length: MemLength, source_handle: i32) -> i32 {
-        let result = VMHooks::big_int_storage_store_unsigned(self, key_offset, key_length, source_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_storage_store_unsigned(&self, key_offset: MemPtr, key_length: MemLength, source_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_storage_store_unsigned(inner, key_offset, key_length, source_handle))
     }
 
-    fn big_int_storage_load_unsigned(&mut self, key_offset: MemPtr, key_length: MemLength, destination_handle: i32) -> i32 {
-        let result = VMHooks::big_int_storage_load_unsigned(self, key_offset, key_length, destination_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_storage_load_unsigned(&self, key_offset: MemPtr, key_length: MemLength, destination_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_storage_load_unsigned(inner, key_offset, key_length, destination_handle))
     }
 
-    fn big_int_get_call_value(&mut self, destination_handle: i32) {
-        let result = VMHooks::big_int_get_call_value(self, destination_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_get_call_value(&self, destination_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_get_call_value(inner, destination_handle))
     }
 
-    fn big_int_get_esdt_call_value(&mut self, destination: i32) {
-        let result = VMHooks::big_int_get_esdt_call_value(self, destination);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_get_esdt_call_value(&self, destination: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_get_esdt_call_value(inner, destination))
     }
 
-    fn big_int_get_esdt_call_value_by_index(&mut self, destination_handle: i32, index: i32) {
-        let result = VMHooks::big_int_get_esdt_call_value_by_index(self, destination_handle, index);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_get_esdt_call_value_by_index(&self, destination_handle: i32, index: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_get_esdt_call_value_by_index(inner, destination_handle, index))
     }
 
-    fn big_int_get_external_balance(&mut self, address_offset: MemPtr, result: i32) {
-        let result = VMHooks::big_int_get_external_balance(self, address_offset, result);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_get_external_balance(&self, address_offset: MemPtr, result: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_get_external_balance(inner, address_offset, result))
     }
 
-    fn big_int_get_esdt_external_balance(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, result_handle: i32) {
-        let result = VMHooks::big_int_get_esdt_external_balance(self, address_offset, token_id_offset, token_id_len, nonce, result_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_get_esdt_external_balance(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, result_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_get_esdt_external_balance(inner, address_offset, token_id_offset, token_id_len, nonce, result_handle))
     }
 
-    fn big_int_new(&mut self, small_value: i64) -> i32 {
-        let result = VMHooks::big_int_new(self, small_value);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_new(&self, small_value: i64) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_new(inner, small_value))
     }
 
-    fn big_int_unsigned_byte_length(&mut self, reference_handle: i32) -> i32 {
-        let result = VMHooks::big_int_unsigned_byte_length(self, reference_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_unsigned_byte_length(&self, reference_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_unsigned_byte_length(inner, reference_handle))
     }
 
-    fn big_int_signed_byte_length(&mut self, reference_handle: i32) -> i32 {
-        let result = VMHooks::big_int_signed_byte_length(self, reference_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_signed_byte_length(&self, reference_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_signed_byte_length(inner, reference_handle))
     }
 
-    fn big_int_get_unsigned_bytes(&mut self, reference_handle: i32, byte_offset: MemPtr) -> i32 {
-        let result = VMHooks::big_int_get_unsigned_bytes(self, reference_handle, byte_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_get_unsigned_bytes(&self, reference_handle: i32, byte_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_get_unsigned_bytes(inner, reference_handle, byte_offset))
     }
 
-    fn big_int_get_signed_bytes(&mut self, reference_handle: i32, byte_offset: MemPtr) -> i32 {
-        let result = VMHooks::big_int_get_signed_bytes(self, reference_handle, byte_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_get_signed_bytes(&self, reference_handle: i32, byte_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_get_signed_bytes(inner, reference_handle, byte_offset))
     }
 
-    fn big_int_set_unsigned_bytes(&mut self, destination_handle: i32, byte_offset: MemPtr, byte_length: MemLength) {
-        let result = VMHooks::big_int_set_unsigned_bytes(self, destination_handle, byte_offset, byte_length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_set_unsigned_bytes(&self, destination_handle: i32, byte_offset: MemPtr, byte_length: MemLength) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_set_unsigned_bytes(inner, destination_handle, byte_offset, byte_length))
     }
 
-    fn big_int_set_signed_bytes(&mut self, destination_handle: i32, byte_offset: MemPtr, byte_length: MemLength) {
-        let result = VMHooks::big_int_set_signed_bytes(self, destination_handle, byte_offset, byte_length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_set_signed_bytes(&self, destination_handle: i32, byte_offset: MemPtr, byte_length: MemLength) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_set_signed_bytes(inner, destination_handle, byte_offset, byte_length))
     }
 
-    fn big_int_is_int64(&mut self, destination_handle: i32) -> i32 {
-        let result = VMHooks::big_int_is_int64(self, destination_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_is_int64(&self, destination_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_is_int64(inner, destination_handle))
     }
 
-    fn big_int_get_int64(&mut self, destination_handle: i32) -> i64 {
-        let result = VMHooks::big_int_get_int64(self, destination_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_get_int64(&self, destination_handle: i32) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_get_int64(inner, destination_handle))
     }
 
-    fn big_int_set_int64(&mut self, destination_handle: i32, value: i64) {
-        let result = VMHooks::big_int_set_int64(self, destination_handle, value);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_set_int64(&self, destination_handle: i32, value: i64) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_set_int64(inner, destination_handle, value))
     }
 
-    fn big_int_add(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-        let result = VMHooks::big_int_add(self, destination_handle, op1_handle, op2_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_add(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_add(inner, destination_handle, op1_handle, op2_handle))
     }
 
-    fn big_int_sub(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-        let result = VMHooks::big_int_sub(self, destination_handle, op1_handle, op2_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_sub(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_sub(inner, destination_handle, op1_handle, op2_handle))
     }
 
-    fn big_int_mul(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-        let result = VMHooks::big_int_mul(self, destination_handle, op1_handle, op2_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_mul(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_mul(inner, destination_handle, op1_handle, op2_handle))
     }
 
-    fn big_int_tdiv(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-        let result = VMHooks::big_int_tdiv(self, destination_handle, op1_handle, op2_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_tdiv(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_tdiv(inner, destination_handle, op1_handle, op2_handle))
     }
 
-    fn big_int_tmod(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-        let result = VMHooks::big_int_tmod(self, destination_handle, op1_handle, op2_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_tmod(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_tmod(inner, destination_handle, op1_handle, op2_handle))
     }
 
-    fn big_int_ediv(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-        let result = VMHooks::big_int_ediv(self, destination_handle, op1_handle, op2_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_ediv(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_ediv(inner, destination_handle, op1_handle, op2_handle))
     }
 
-    fn big_int_emod(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-        let result = VMHooks::big_int_emod(self, destination_handle, op1_handle, op2_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_emod(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_emod(inner, destination_handle, op1_handle, op2_handle))
     }
 
-    fn big_int_sqrt(&mut self, destination_handle: i32, op_handle: i32) {
-        let result = VMHooks::big_int_sqrt(self, destination_handle, op_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_sqrt(&self, destination_handle: i32, op_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_sqrt(inner, destination_handle, op_handle))
     }
 
-    fn big_int_pow(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-        let result = VMHooks::big_int_pow(self, destination_handle, op1_handle, op2_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_pow(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_pow(inner, destination_handle, op1_handle, op2_handle))
     }
 
-    fn big_int_log2(&mut self, op1_handle: i32) -> i32 {
-        let result = VMHooks::big_int_log2(self, op1_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_log2(&self, op1_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_log2(inner, op1_handle))
     }
 
-    fn big_int_abs(&mut self, destination_handle: i32, op_handle: i32) {
-        let result = VMHooks::big_int_abs(self, destination_handle, op_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_abs(&self, destination_handle: i32, op_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_abs(inner, destination_handle, op_handle))
     }
 
-    fn big_int_neg(&mut self, destination_handle: i32, op_handle: i32) {
-        let result = VMHooks::big_int_neg(self, destination_handle, op_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_neg(&self, destination_handle: i32, op_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_neg(inner, destination_handle, op_handle))
     }
 
-    fn big_int_sign(&mut self, op_handle: i32) -> i32 {
-        let result = VMHooks::big_int_sign(self, op_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_sign(&self, op_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_sign(inner, op_handle))
     }
 
-    fn big_int_cmp(&mut self, op1_handle: i32, op2_handle: i32) -> i32 {
-        let result = VMHooks::big_int_cmp(self, op1_handle, op2_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_cmp(&self, op1_handle: i32, op2_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_cmp(inner, op1_handle, op2_handle))
     }
 
-    fn big_int_not(&mut self, destination_handle: i32, op_handle: i32) {
-        let result = VMHooks::big_int_not(self, destination_handle, op_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_not(&self, destination_handle: i32, op_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_not(inner, destination_handle, op_handle))
     }
 
-    fn big_int_and(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-        let result = VMHooks::big_int_and(self, destination_handle, op1_handle, op2_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_and(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_and(inner, destination_handle, op1_handle, op2_handle))
     }
 
-    fn big_int_or(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-        let result = VMHooks::big_int_or(self, destination_handle, op1_handle, op2_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_or(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_or(inner, destination_handle, op1_handle, op2_handle))
     }
 
-    fn big_int_xor(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
-        let result = VMHooks::big_int_xor(self, destination_handle, op1_handle, op2_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_xor(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_xor(inner, destination_handle, op1_handle, op2_handle))
     }
 
-    fn big_int_shr(&mut self, destination_handle: i32, op_handle: i32, bits: i32) {
-        let result = VMHooks::big_int_shr(self, destination_handle, op_handle, bits);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_shr(&self, destination_handle: i32, op_handle: i32, bits: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_shr(inner, destination_handle, op_handle, bits))
     }
 
-    fn big_int_shl(&mut self, destination_handle: i32, op_handle: i32, bits: i32) {
-        let result = VMHooks::big_int_shl(self, destination_handle, op_handle, bits);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_shl(&self, destination_handle: i32, op_handle: i32, bits: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_shl(inner, destination_handle, op_handle, bits))
     }
 
-    fn big_int_finish_unsigned(&mut self, reference_handle: i32) {
-        let result = VMHooks::big_int_finish_unsigned(self, reference_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_finish_unsigned(&self, reference_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_finish_unsigned(inner, reference_handle))
     }
 
-    fn big_int_finish_signed(&mut self, reference_handle: i32) {
-        let result = VMHooks::big_int_finish_signed(self, reference_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_finish_signed(&self, reference_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_finish_signed(inner, reference_handle))
     }
 
-    fn big_int_to_string(&mut self, big_int_handle: i32, destination_handle: i32) {
-        let result = VMHooks::big_int_to_string(self, big_int_handle, destination_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn big_int_to_string(&self, big_int_handle: i32, destination_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::big_int_to_string(inner, big_int_handle, destination_handle))
     }
 
-    fn mbuffer_new(&mut self) -> i32 {
-        let result = VMHooks::mbuffer_new(self);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_new(&self) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_new(inner))
     }
 
-    fn mbuffer_new_from_bytes(&mut self, data_offset: MemPtr, data_length: MemLength) -> i32 {
-        let result = VMHooks::mbuffer_new_from_bytes(self, data_offset, data_length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_new_from_bytes(&self, data_offset: MemPtr, data_length: MemLength) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_new_from_bytes(inner, data_offset, data_length))
     }
 
-    fn mbuffer_get_length(&mut self, m_buffer_handle: i32) -> i32 {
-        let result = VMHooks::mbuffer_get_length(self, m_buffer_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_get_length(&self, m_buffer_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_get_length(inner, m_buffer_handle))
     }
 
-    fn mbuffer_get_bytes(&mut self, m_buffer_handle: i32, result_offset: MemPtr) -> i32 {
-        let result = VMHooks::mbuffer_get_bytes(self, m_buffer_handle, result_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_get_bytes(&self, m_buffer_handle: i32, result_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_get_bytes(inner, m_buffer_handle, result_offset))
     }
 
-    fn mbuffer_get_byte_slice(&mut self, source_handle: i32, starting_position: i32, slice_length: i32, result_offset: MemPtr) -> i32 {
-        let result = VMHooks::mbuffer_get_byte_slice(self, source_handle, starting_position, slice_length, result_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_get_byte_slice(&self, source_handle: i32, starting_position: i32, slice_length: i32, result_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_get_byte_slice(inner, source_handle, starting_position, slice_length, result_offset))
     }
 
-    fn mbuffer_copy_byte_slice(&mut self, source_handle: i32, starting_position: i32, slice_length: i32, destination_handle: i32) -> i32 {
-        let result = VMHooks::mbuffer_copy_byte_slice(self, source_handle, starting_position, slice_length, destination_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_copy_byte_slice(&self, source_handle: i32, starting_position: i32, slice_length: i32, destination_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_copy_byte_slice(inner, source_handle, starting_position, slice_length, destination_handle))
     }
 
-    fn mbuffer_eq(&mut self, m_buffer_handle1: i32, m_buffer_handle2: i32) -> i32 {
-        let result = VMHooks::mbuffer_eq(self, m_buffer_handle1, m_buffer_handle2);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_eq(&self, m_buffer_handle1: i32, m_buffer_handle2: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_eq(inner, m_buffer_handle1, m_buffer_handle2))
     }
 
-    fn mbuffer_set_bytes(&mut self, m_buffer_handle: i32, data_offset: MemPtr, data_length: MemLength) -> i32 {
-        let result = VMHooks::mbuffer_set_bytes(self, m_buffer_handle, data_offset, data_length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_set_bytes(&self, m_buffer_handle: i32, data_offset: MemPtr, data_length: MemLength) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_set_bytes(inner, m_buffer_handle, data_offset, data_length))
     }
 
-    fn mbuffer_set_byte_slice(&mut self, m_buffer_handle: i32, starting_position: i32, data_length: MemLength, data_offset: MemPtr) -> i32 {
-        let result = VMHooks::mbuffer_set_byte_slice(self, m_buffer_handle, starting_position, data_length, data_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_set_byte_slice(&self, m_buffer_handle: i32, starting_position: i32, data_length: MemLength, data_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_set_byte_slice(inner, m_buffer_handle, starting_position, data_length, data_offset))
     }
 
-    fn mbuffer_append(&mut self, accumulator_handle: i32, data_handle: i32) -> i32 {
-        let result = VMHooks::mbuffer_append(self, accumulator_handle, data_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_append(&self, accumulator_handle: i32, data_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_append(inner, accumulator_handle, data_handle))
     }
 
-    fn mbuffer_append_bytes(&mut self, accumulator_handle: i32, data_offset: MemPtr, data_length: MemLength) -> i32 {
-        let result = VMHooks::mbuffer_append_bytes(self, accumulator_handle, data_offset, data_length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_append_bytes(&self, accumulator_handle: i32, data_offset: MemPtr, data_length: MemLength) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_append_bytes(inner, accumulator_handle, data_offset, data_length))
     }
 
-    fn mbuffer_to_big_int_unsigned(&mut self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
-        let result = VMHooks::mbuffer_to_big_int_unsigned(self, m_buffer_handle, big_int_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_to_big_int_unsigned(&self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_to_big_int_unsigned(inner, m_buffer_handle, big_int_handle))
     }
 
-    fn mbuffer_to_big_int_signed(&mut self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
-        let result = VMHooks::mbuffer_to_big_int_signed(self, m_buffer_handle, big_int_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_to_big_int_signed(&self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_to_big_int_signed(inner, m_buffer_handle, big_int_handle))
     }
 
-    fn mbuffer_from_big_int_unsigned(&mut self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
-        let result = VMHooks::mbuffer_from_big_int_unsigned(self, m_buffer_handle, big_int_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_from_big_int_unsigned(&self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_from_big_int_unsigned(inner, m_buffer_handle, big_int_handle))
     }
 
-    fn mbuffer_from_big_int_signed(&mut self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
-        let result = VMHooks::mbuffer_from_big_int_signed(self, m_buffer_handle, big_int_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_from_big_int_signed(&self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_from_big_int_signed(inner, m_buffer_handle, big_int_handle))
     }
 
-    fn mbuffer_to_big_float(&mut self, m_buffer_handle: i32, big_float_handle: i32) -> i32 {
-        let result = VMHooks::mbuffer_to_big_float(self, m_buffer_handle, big_float_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_to_big_float(&self, m_buffer_handle: i32, big_float_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_to_big_float(inner, m_buffer_handle, big_float_handle))
     }
 
-    fn mbuffer_from_big_float(&mut self, m_buffer_handle: i32, big_float_handle: i32) -> i32 {
-        let result = VMHooks::mbuffer_from_big_float(self, m_buffer_handle, big_float_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_from_big_float(&self, m_buffer_handle: i32, big_float_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_from_big_float(inner, m_buffer_handle, big_float_handle))
     }
 
-    fn mbuffer_storage_store(&mut self, key_handle: i32, source_handle: i32) -> i32 {
-        let result = VMHooks::mbuffer_storage_store(self, key_handle, source_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_storage_store(&self, key_handle: i32, source_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_storage_store(inner, key_handle, source_handle))
     }
 
-    fn mbuffer_storage_load(&mut self, key_handle: i32, destination_handle: i32) -> i32 {
-        let result = VMHooks::mbuffer_storage_load(self, key_handle, destination_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_storage_load(&self, key_handle: i32, destination_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_storage_load(inner, key_handle, destination_handle))
     }
 
-    fn mbuffer_storage_load_from_address(&mut self, address_handle: i32, key_handle: i32, destination_handle: i32) {
-        let result = VMHooks::mbuffer_storage_load_from_address(self, address_handle, key_handle, destination_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_storage_load_from_address(&self, address_handle: i32, key_handle: i32, destination_handle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_storage_load_from_address(inner, address_handle, key_handle, destination_handle))
     }
 
-    fn mbuffer_get_argument(&mut self, id: i32, destination_handle: i32) -> i32 {
-        let result = VMHooks::mbuffer_get_argument(self, id, destination_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_get_argument(&self, id: i32, destination_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_get_argument(inner, id, destination_handle))
     }
 
-    fn mbuffer_finish(&mut self, source_handle: i32) -> i32 {
-        let result = VMHooks::mbuffer_finish(self, source_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_finish(&self, source_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_finish(inner, source_handle))
     }
 
-    fn mbuffer_set_random(&mut self, destination_handle: i32, length: i32) -> i32 {
-        let result = VMHooks::mbuffer_set_random(self, destination_handle, length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn mbuffer_set_random(&self, destination_handle: i32, length: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::mbuffer_set_random(inner, destination_handle, length))
     }
 
-    fn managed_map_new(&mut self) -> i32 {
-        let result = VMHooks::managed_map_new(self);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_map_new(&self) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_map_new(inner))
     }
 
-    fn managed_map_put(&mut self, m_map_handle: i32, key_handle: i32, value_handle: i32) -> i32 {
-        let result = VMHooks::managed_map_put(self, m_map_handle, key_handle, value_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_map_put(&self, m_map_handle: i32, key_handle: i32, value_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_map_put(inner, m_map_handle, key_handle, value_handle))
     }
 
-    fn managed_map_get(&mut self, m_map_handle: i32, key_handle: i32, out_value_handle: i32) -> i32 {
-        let result = VMHooks::managed_map_get(self, m_map_handle, key_handle, out_value_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_map_get(&self, m_map_handle: i32, key_handle: i32, out_value_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_map_get(inner, m_map_handle, key_handle, out_value_handle))
     }
 
-    fn managed_map_remove(&mut self, m_map_handle: i32, key_handle: i32, out_value_handle: i32) -> i32 {
-        let result = VMHooks::managed_map_remove(self, m_map_handle, key_handle, out_value_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_map_remove(&self, m_map_handle: i32, key_handle: i32, out_value_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_map_remove(inner, m_map_handle, key_handle, out_value_handle))
     }
 
-    fn managed_map_contains(&mut self, m_map_handle: i32, key_handle: i32) -> i32 {
-        let result = VMHooks::managed_map_contains(self, m_map_handle, key_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_map_contains(&self, m_map_handle: i32, key_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_map_contains(inner, m_map_handle, key_handle))
     }
 
-    fn small_int_get_unsigned_argument(&mut self, id: i32) -> i64 {
-        let result = VMHooks::small_int_get_unsigned_argument(self, id);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn small_int_get_unsigned_argument(&self, id: i32) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::small_int_get_unsigned_argument(inner, id))
     }
 
-    fn small_int_get_signed_argument(&mut self, id: i32) -> i64 {
-        let result = VMHooks::small_int_get_signed_argument(self, id);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn small_int_get_signed_argument(&self, id: i32) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::small_int_get_signed_argument(inner, id))
     }
 
-    fn small_int_finish_unsigned(&mut self, value: i64) {
-        let result = VMHooks::small_int_finish_unsigned(self, value);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn small_int_finish_unsigned(&self, value: i64) {
+        self.adapt_vm_hooks(|inner| VMHooks::small_int_finish_unsigned(inner, value))
     }
 
-    fn small_int_finish_signed(&mut self, value: i64) {
-        let result = VMHooks::small_int_finish_signed(self, value);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn small_int_finish_signed(&self, value: i64) {
+        self.adapt_vm_hooks(|inner| VMHooks::small_int_finish_signed(inner, value))
     }
 
-    fn small_int_storage_store_unsigned(&mut self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32 {
-        let result = VMHooks::small_int_storage_store_unsigned(self, key_offset, key_length, value);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn small_int_storage_store_unsigned(&self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::small_int_storage_store_unsigned(inner, key_offset, key_length, value))
     }
 
-    fn small_int_storage_store_signed(&mut self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32 {
-        let result = VMHooks::small_int_storage_store_signed(self, key_offset, key_length, value);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn small_int_storage_store_signed(&self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::small_int_storage_store_signed(inner, key_offset, key_length, value))
     }
 
-    fn small_int_storage_load_unsigned(&mut self, key_offset: MemPtr, key_length: MemLength) -> i64 {
-        let result = VMHooks::small_int_storage_load_unsigned(self, key_offset, key_length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn small_int_storage_load_unsigned(&self, key_offset: MemPtr, key_length: MemLength) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::small_int_storage_load_unsigned(inner, key_offset, key_length))
     }
 
-    fn small_int_storage_load_signed(&mut self, key_offset: MemPtr, key_length: MemLength) -> i64 {
-        let result = VMHooks::small_int_storage_load_signed(self, key_offset, key_length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn small_int_storage_load_signed(&self, key_offset: MemPtr, key_length: MemLength) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::small_int_storage_load_signed(inner, key_offset, key_length))
     }
 
-    fn int64get_argument(&mut self, id: i32) -> i64 {
-        let result = VMHooks::int64get_argument(self, id);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn int64get_argument(&self, id: i32) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::int64get_argument(inner, id))
     }
 
-    fn int64finish(&mut self, value: i64) {
-        let result = VMHooks::int64finish(self, value);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn int64finish(&self, value: i64) {
+        self.adapt_vm_hooks(|inner| VMHooks::int64finish(inner, value))
     }
 
-    fn int64storage_store(&mut self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32 {
-        let result = VMHooks::int64storage_store(self, key_offset, key_length, value);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn int64storage_store(&self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::int64storage_store(inner, key_offset, key_length, value))
     }
 
-    fn int64storage_load(&mut self, key_offset: MemPtr, key_length: MemLength) -> i64 {
-        let result = VMHooks::int64storage_load(self, key_offset, key_length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn int64storage_load(&self, key_offset: MemPtr, key_length: MemLength) -> i64 {
+        self.adapt_vm_hooks(|inner| VMHooks::int64storage_load(inner, key_offset, key_length))
     }
 
-    fn sha256(&mut self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32 {
-        let result = VMHooks::sha256(self, data_offset, length, result_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn sha256(&self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::sha256(inner, data_offset, length, result_offset))
     }
 
-    fn managed_sha256(&mut self, input_handle: i32, output_handle: i32) -> i32 {
-        let result = VMHooks::managed_sha256(self, input_handle, output_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_sha256(&self, input_handle: i32, output_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_sha256(inner, input_handle, output_handle))
     }
 
-    fn keccak256(&mut self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32 {
-        let result = VMHooks::keccak256(self, data_offset, length, result_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn keccak256(&self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::keccak256(inner, data_offset, length, result_offset))
     }
 
-    fn managed_keccak256(&mut self, input_handle: i32, output_handle: i32) -> i32 {
-        let result = VMHooks::managed_keccak256(self, input_handle, output_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_keccak256(&self, input_handle: i32, output_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_keccak256(inner, input_handle, output_handle))
     }
 
-    fn ripemd160(&mut self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32 {
-        let result = VMHooks::ripemd160(self, data_offset, length, result_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn ripemd160(&self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::ripemd160(inner, data_offset, length, result_offset))
     }
 
-    fn managed_ripemd160(&mut self, input_handle: i32, output_handle: i32) -> i32 {
-        let result = VMHooks::managed_ripemd160(self, input_handle, output_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_ripemd160(&self, input_handle: i32, output_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_ripemd160(inner, input_handle, output_handle))
     }
 
-    fn verify_bls(&mut self, key_offset: MemPtr, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32 {
-        let result = VMHooks::verify_bls(self, key_offset, message_offset, message_length, sig_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn verify_bls(&self, key_offset: MemPtr, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::verify_bls(inner, key_offset, message_offset, message_length, sig_offset))
     }
 
-    fn managed_verify_bls(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
-        let result = VMHooks::managed_verify_bls(self, key_handle, message_handle, sig_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_verify_bls(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_verify_bls(inner, key_handle, message_handle, sig_handle))
     }
 
-    fn verify_ed25519(&mut self, key_offset: MemPtr, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32 {
-        let result = VMHooks::verify_ed25519(self, key_offset, message_offset, message_length, sig_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn verify_ed25519(&self, key_offset: MemPtr, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::verify_ed25519(inner, key_offset, message_offset, message_length, sig_offset))
     }
 
-    fn managed_verify_ed25519(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
-        let result = VMHooks::managed_verify_ed25519(self, key_handle, message_handle, sig_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_verify_ed25519(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_verify_ed25519(inner, key_handle, message_handle, sig_handle))
     }
 
-    fn verify_custom_secp256k1(&mut self, key_offset: MemPtr, key_length: MemLength, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr, hash_type: i32) -> i32 {
-        let result = VMHooks::verify_custom_secp256k1(self, key_offset, key_length, message_offset, message_length, sig_offset, hash_type);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn verify_custom_secp256k1(&self, key_offset: MemPtr, key_length: MemLength, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr, hash_type: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::verify_custom_secp256k1(inner, key_offset, key_length, message_offset, message_length, sig_offset, hash_type))
     }
 
-    fn managed_verify_custom_secp256k1(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32, hash_type: i32) -> i32 {
-        let result = VMHooks::managed_verify_custom_secp256k1(self, key_handle, message_handle, sig_handle, hash_type);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_verify_custom_secp256k1(&self, key_handle: i32, message_handle: i32, sig_handle: i32, hash_type: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_verify_custom_secp256k1(inner, key_handle, message_handle, sig_handle, hash_type))
     }
 
-    fn verify_secp256k1(&mut self, key_offset: MemPtr, key_length: MemLength, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32 {
-        let result = VMHooks::verify_secp256k1(self, key_offset, key_length, message_offset, message_length, sig_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn verify_secp256k1(&self, key_offset: MemPtr, key_length: MemLength, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::verify_secp256k1(inner, key_offset, key_length, message_offset, message_length, sig_offset))
     }
 
-    fn managed_verify_secp256k1(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
-        let result = VMHooks::managed_verify_secp256k1(self, key_handle, message_handle, sig_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_verify_secp256k1(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_verify_secp256k1(inner, key_handle, message_handle, sig_handle))
     }
 
-    fn encode_secp256k1_der_signature(&mut self, r_offset: MemPtr, r_length: MemLength, s_offset: MemPtr, s_length: MemLength, sig_offset: MemPtr) -> i32 {
-        let result = VMHooks::encode_secp256k1_der_signature(self, r_offset, r_length, s_offset, s_length, sig_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn encode_secp256k1_der_signature(&self, r_offset: MemPtr, r_length: MemLength, s_offset: MemPtr, s_length: MemLength, sig_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::encode_secp256k1_der_signature(inner, r_offset, r_length, s_offset, s_length, sig_offset))
     }
 
-    fn managed_encode_secp256k1_der_signature(&mut self, r_handle: i32, s_handle: i32, sig_handle: i32) -> i32 {
-        let result = VMHooks::managed_encode_secp256k1_der_signature(self, r_handle, s_handle, sig_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_encode_secp256k1_der_signature(&self, r_handle: i32, s_handle: i32, sig_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_encode_secp256k1_der_signature(inner, r_handle, s_handle, sig_handle))
     }
 
-    fn add_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, fst_point_xhandle: i32, fst_point_yhandle: i32, snd_point_xhandle: i32, snd_point_yhandle: i32) {
-        let result = VMHooks::add_ec(self, x_result_handle, y_result_handle, ec_handle, fst_point_xhandle, fst_point_yhandle, snd_point_xhandle, snd_point_yhandle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn add_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, fst_point_xhandle: i32, fst_point_yhandle: i32, snd_point_xhandle: i32, snd_point_yhandle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::add_ec(inner, x_result_handle, y_result_handle, ec_handle, fst_point_xhandle, fst_point_yhandle, snd_point_xhandle, snd_point_yhandle))
     }
 
-    fn double_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32) {
-        let result = VMHooks::double_ec(self, x_result_handle, y_result_handle, ec_handle, point_xhandle, point_yhandle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn double_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32) {
+        self.adapt_vm_hooks(|inner| VMHooks::double_ec(inner, x_result_handle, y_result_handle, ec_handle, point_xhandle, point_yhandle))
     }
 
-    fn is_on_curve_ec(&mut self, ec_handle: i32, point_xhandle: i32, point_yhandle: i32) -> i32 {
-        let result = VMHooks::is_on_curve_ec(self, ec_handle, point_xhandle, point_yhandle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn is_on_curve_ec(&self, ec_handle: i32, point_xhandle: i32, point_yhandle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::is_on_curve_ec(inner, ec_handle, point_xhandle, point_yhandle))
     }
 
-    fn scalar_base_mult_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
-        let result = VMHooks::scalar_base_mult_ec(self, x_result_handle, y_result_handle, ec_handle, data_offset, length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn scalar_base_mult_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::scalar_base_mult_ec(inner, x_result_handle, y_result_handle, ec_handle, data_offset, length))
     }
 
-    fn managed_scalar_base_mult_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
-        let result = VMHooks::managed_scalar_base_mult_ec(self, x_result_handle, y_result_handle, ec_handle, data_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_scalar_base_mult_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_scalar_base_mult_ec(inner, x_result_handle, y_result_handle, ec_handle, data_handle))
     }
 
-    fn scalar_mult_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
-        let result = VMHooks::scalar_mult_ec(self, x_result_handle, y_result_handle, ec_handle, point_xhandle, point_yhandle, data_offset, length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn scalar_mult_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::scalar_mult_ec(inner, x_result_handle, y_result_handle, ec_handle, point_xhandle, point_yhandle, data_offset, length))
     }
 
-    fn managed_scalar_mult_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32, data_handle: i32) -> i32 {
-        let result = VMHooks::managed_scalar_mult_ec(self, x_result_handle, y_result_handle, ec_handle, point_xhandle, point_yhandle, data_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_scalar_mult_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32, data_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_scalar_mult_ec(inner, x_result_handle, y_result_handle, ec_handle, point_xhandle, point_yhandle, data_handle))
     }
 
-    fn marshal_ec(&mut self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32 {
-        let result = VMHooks::marshal_ec(self, x_pair_handle, y_pair_handle, ec_handle, result_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn marshal_ec(&self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::marshal_ec(inner, x_pair_handle, y_pair_handle, ec_handle, result_offset))
     }
 
-    fn managed_marshal_ec(&mut self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
-        let result = VMHooks::managed_marshal_ec(self, x_pair_handle, y_pair_handle, ec_handle, result_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_marshal_ec(&self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_marshal_ec(inner, x_pair_handle, y_pair_handle, ec_handle, result_handle))
     }
 
-    fn marshal_compressed_ec(&mut self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32 {
-        let result = VMHooks::marshal_compressed_ec(self, x_pair_handle, y_pair_handle, ec_handle, result_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn marshal_compressed_ec(&self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::marshal_compressed_ec(inner, x_pair_handle, y_pair_handle, ec_handle, result_offset))
     }
 
-    fn managed_marshal_compressed_ec(&mut self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
-        let result = VMHooks::managed_marshal_compressed_ec(self, x_pair_handle, y_pair_handle, ec_handle, result_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_marshal_compressed_ec(&self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_marshal_compressed_ec(inner, x_pair_handle, y_pair_handle, ec_handle, result_handle))
     }
 
-    fn unmarshal_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
-        let result = VMHooks::unmarshal_ec(self, x_result_handle, y_result_handle, ec_handle, data_offset, length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn unmarshal_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::unmarshal_ec(inner, x_result_handle, y_result_handle, ec_handle, data_offset, length))
     }
 
-    fn managed_unmarshal_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
-        let result = VMHooks::managed_unmarshal_ec(self, x_result_handle, y_result_handle, ec_handle, data_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_unmarshal_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_unmarshal_ec(inner, x_result_handle, y_result_handle, ec_handle, data_handle))
     }
 
-    fn unmarshal_compressed_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
-        let result = VMHooks::unmarshal_compressed_ec(self, x_result_handle, y_result_handle, ec_handle, data_offset, length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn unmarshal_compressed_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::unmarshal_compressed_ec(inner, x_result_handle, y_result_handle, ec_handle, data_offset, length))
     }
 
-    fn managed_unmarshal_compressed_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
-        let result = VMHooks::managed_unmarshal_compressed_ec(self, x_result_handle, y_result_handle, ec_handle, data_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_unmarshal_compressed_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_unmarshal_compressed_ec(inner, x_result_handle, y_result_handle, ec_handle, data_handle))
     }
 
-    fn generate_key_ec(&mut self, x_pub_key_handle: i32, y_pub_key_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32 {
-        let result = VMHooks::generate_key_ec(self, x_pub_key_handle, y_pub_key_handle, ec_handle, result_offset);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn generate_key_ec(&self, x_pub_key_handle: i32, y_pub_key_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::generate_key_ec(inner, x_pub_key_handle, y_pub_key_handle, ec_handle, result_offset))
     }
 
-    fn managed_generate_key_ec(&mut self, x_pub_key_handle: i32, y_pub_key_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
-        let result = VMHooks::managed_generate_key_ec(self, x_pub_key_handle, y_pub_key_handle, ec_handle, result_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_generate_key_ec(&self, x_pub_key_handle: i32, y_pub_key_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_generate_key_ec(inner, x_pub_key_handle, y_pub_key_handle, ec_handle, result_handle))
     }
 
-    fn create_ec(&mut self, data_offset: MemPtr, data_length: MemLength) -> i32 {
-        let result = VMHooks::create_ec(self, data_offset, data_length);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn create_ec(&self, data_offset: MemPtr, data_length: MemLength) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::create_ec(inner, data_offset, data_length))
     }
 
-    fn managed_create_ec(&mut self, data_handle: i32) -> i32 {
-        let result = VMHooks::managed_create_ec(self, data_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_create_ec(&self, data_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_create_ec(inner, data_handle))
     }
 
-    fn get_curve_length_ec(&mut self, ec_handle: i32) -> i32 {
-        let result = VMHooks::get_curve_length_ec(self, ec_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_curve_length_ec(&self, ec_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_curve_length_ec(inner, ec_handle))
     }
 
-    fn get_priv_key_byte_length_ec(&mut self, ec_handle: i32) -> i32 {
-        let result = VMHooks::get_priv_key_byte_length_ec(self, ec_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn get_priv_key_byte_length_ec(&self, ec_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::get_priv_key_byte_length_ec(inner, ec_handle))
     }
 
-    fn elliptic_curve_get_values(&mut self, ec_handle: i32, field_order_handle: i32, base_point_order_handle: i32, eq_constant_handle: i32, x_base_point_handle: i32, y_base_point_handle: i32) -> i32 {
-        let result = VMHooks::elliptic_curve_get_values(self, ec_handle, field_order_handle, base_point_order_handle, eq_constant_handle, x_base_point_handle, y_base_point_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn elliptic_curve_get_values(&self, ec_handle: i32, field_order_handle: i32, base_point_order_handle: i32, eq_constant_handle: i32, x_base_point_handle: i32, y_base_point_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::elliptic_curve_get_values(inner, ec_handle, field_order_handle, base_point_order_handle, eq_constant_handle, x_base_point_handle, y_base_point_handle))
     }
 
-    fn managed_verify_secp256r1(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
-        let result = VMHooks::managed_verify_secp256r1(self, key_handle, message_handle, sig_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_verify_secp256r1(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_verify_secp256r1(inner, key_handle, message_handle, sig_handle))
     }
 
-    fn managed_verify_blssignature_share(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
-        let result = VMHooks::managed_verify_blssignature_share(self, key_handle, message_handle, sig_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_verify_blssignature_share(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_verify_blssignature_share(inner, key_handle, message_handle, sig_handle))
     }
 
-    fn managed_verify_blsaggregated_signature(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
-        let result = VMHooks::managed_verify_blsaggregated_signature(self, key_handle, message_handle, sig_handle);
-        Self::unwrap_or_set_breakpoint(self, result)
+    fn managed_verify_blsaggregated_signature(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
+        self.adapt_vm_hooks(|inner| VMHooks::managed_verify_blsaggregated_signature(inner, key_handle, message_handle, sig_handle))
     }
 }

--- a/vm-executor/src/vm_hooks.rs
+++ b/vm-executor/src/vm_hooks.rs
@@ -13,268 +13,268 @@ use crate::{MemLength, MemPtr};
 pub trait VMHooksLegacy: core::fmt::Debug {
     fn set_vm_hooks_ptr(&mut self, vm_hooks_ptr: *mut c_void);
 
-    fn get_gas_left(&mut self) -> i64;
-    fn get_sc_address(&mut self, result_offset: MemPtr);
-    fn get_owner_address(&mut self, result_offset: MemPtr);
-    fn get_shard_of_address(&mut self, address_offset: MemPtr) -> i32;
-    fn is_smart_contract(&mut self, address_offset: MemPtr) -> i32;
-    fn signal_error(&mut self, message_offset: MemPtr, message_length: MemLength);
-    fn get_external_balance(&mut self, address_offset: MemPtr, result_offset: MemPtr);
-    fn get_block_hash(&mut self, nonce: i64, result_offset: MemPtr) -> i32;
-    fn get_esdt_balance(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, result_offset: MemPtr) -> i32;
-    fn get_esdt_nft_name_length(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32;
-    fn get_esdt_nft_attribute_length(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32;
-    fn get_esdt_nft_uri_length(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32;
-    fn get_esdt_token_data(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, value_handle: i32, properties_offset: MemPtr, hash_offset: MemPtr, name_offset: MemPtr, attributes_offset: MemPtr, creator_offset: MemPtr, royalties_handle: i32, uris_offset: MemPtr) -> i32;
-    fn get_esdt_local_roles(&mut self, token_id_handle: i32) -> i64;
-    fn validate_token_identifier(&mut self, token_id_handle: i32) -> i32;
-    fn transfer_value(&mut self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, length: MemLength) -> i32;
-    fn transfer_value_execute(&mut self, dest_offset: MemPtr, value_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32;
-    fn transfer_esdt_execute(&mut self, dest_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, value_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32;
-    fn transfer_esdt_nft_execute(&mut self, dest_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, value_offset: MemPtr, nonce: i64, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32;
-    fn multi_transfer_esdt_nft_execute(&mut self, dest_offset: MemPtr, num_token_transfers: i32, token_transfers_args_length_offset: MemPtr, token_transfer_data_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32;
-    fn create_async_call(&mut self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, data_length: MemLength, success_offset: MemPtr, success_length: MemLength, error_offset: MemPtr, error_length: MemLength, gas: i64, extra_gas_for_callback: i64) -> i32;
-    fn set_async_context_callback(&mut self, callback: MemPtr, callback_length: MemLength, data: MemPtr, data_length: MemLength, gas: i64) -> i32;
-    fn upgrade_contract(&mut self, dest_offset: MemPtr, gas_limit: i64, value_offset: MemPtr, code_offset: MemPtr, code_metadata_offset: MemPtr, length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr);
-    fn upgrade_from_source_contract(&mut self, dest_offset: MemPtr, gas_limit: i64, value_offset: MemPtr, source_contract_address_offset: MemPtr, code_metadata_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr);
-    fn delete_contract(&mut self, dest_offset: MemPtr, gas_limit: i64, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr);
-    fn async_call(&mut self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, length: MemLength);
-    fn get_argument_length(&mut self, id: i32) -> i32;
-    fn get_argument(&mut self, id: i32, arg_offset: MemPtr) -> i32;
-    fn get_function(&mut self, function_offset: MemPtr) -> i32;
-    fn get_num_arguments(&mut self) -> i32;
-    fn storage_store(&mut self, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr, data_length: MemLength) -> i32;
-    fn storage_load_length(&mut self, key_offset: MemPtr, key_length: MemLength) -> i32;
-    fn storage_load_from_address(&mut self, address_offset: MemPtr, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr) -> i32;
-    fn storage_load(&mut self, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr) -> i32;
-    fn set_storage_lock(&mut self, key_offset: MemPtr, key_length: MemLength, lock_timestamp: i64) -> i32;
-    fn get_storage_lock(&mut self, key_offset: MemPtr, key_length: MemLength) -> i64;
-    fn is_storage_locked(&mut self, key_offset: MemPtr, key_length: MemLength) -> i32;
-    fn clear_storage_lock(&mut self, key_offset: MemPtr, key_length: MemLength) -> i32;
-    fn get_caller(&mut self, result_offset: MemPtr);
-    fn check_no_payment(&mut self);
-    fn get_call_value(&mut self, result_offset: MemPtr) -> i32;
-    fn get_esdt_value(&mut self, result_offset: MemPtr) -> i32;
-    fn get_esdt_value_by_index(&mut self, result_offset: MemPtr, index: i32) -> i32;
-    fn get_esdt_token_name(&mut self, result_offset: MemPtr) -> i32;
-    fn get_esdt_token_name_by_index(&mut self, result_offset: MemPtr, index: i32) -> i32;
-    fn get_esdt_token_nonce(&mut self) -> i64;
-    fn get_esdt_token_nonce_by_index(&mut self, index: i32) -> i64;
-    fn get_current_esdt_nft_nonce(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength) -> i64;
-    fn get_esdt_token_type(&mut self) -> i32;
-    fn get_esdt_token_type_by_index(&mut self, index: i32) -> i32;
-    fn get_num_esdt_transfers(&mut self) -> i32;
-    fn get_call_value_token_name(&mut self, call_value_offset: MemPtr, token_name_offset: MemPtr) -> i32;
-    fn get_call_value_token_name_by_index(&mut self, call_value_offset: MemPtr, token_name_offset: MemPtr, index: i32) -> i32;
-    fn is_reserved_function_name(&mut self, name_handle: i32) -> i32;
-    fn write_log(&mut self, data_pointer: MemPtr, data_length: MemLength, topic_ptr: MemPtr, num_topics: i32);
-    fn write_event_log(&mut self, num_topics: i32, topic_lengths_offset: MemPtr, topic_offset: MemPtr, data_offset: MemPtr, data_length: MemLength);
-    fn get_block_timestamp(&mut self) -> i64;
-    fn get_block_nonce(&mut self) -> i64;
-    fn get_block_round(&mut self) -> i64;
-    fn get_block_epoch(&mut self) -> i64;
-    fn get_block_random_seed(&mut self, pointer: MemPtr);
-    fn get_state_root_hash(&mut self, pointer: MemPtr);
-    fn get_prev_block_timestamp(&mut self) -> i64;
-    fn get_prev_block_nonce(&mut self) -> i64;
-    fn get_prev_block_round(&mut self) -> i64;
-    fn get_prev_block_epoch(&mut self) -> i64;
-    fn get_prev_block_random_seed(&mut self, pointer: MemPtr);
-    fn finish(&mut self, pointer: MemPtr, length: MemLength);
-    fn execute_on_same_context(&mut self, gas_limit: i64, address_offset: MemPtr, value_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32;
-    fn execute_on_dest_context(&mut self, gas_limit: i64, address_offset: MemPtr, value_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32;
-    fn execute_read_only(&mut self, gas_limit: i64, address_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32;
-    fn create_contract(&mut self, gas_limit: i64, value_offset: MemPtr, code_offset: MemPtr, code_metadata_offset: MemPtr, length: MemLength, result_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32;
-    fn deploy_from_source_contract(&mut self, gas_limit: i64, value_offset: MemPtr, source_contract_address_offset: MemPtr, code_metadata_offset: MemPtr, result_address_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32;
-    fn get_num_return_data(&mut self) -> i32;
-    fn get_return_data_size(&mut self, result_id: i32) -> i32;
-    fn get_return_data(&mut self, result_id: i32, data_offset: MemPtr) -> i32;
-    fn clean_return_data(&mut self);
-    fn delete_from_return_data(&mut self, result_id: i32);
-    fn get_original_tx_hash(&mut self, data_offset: MemPtr);
-    fn get_current_tx_hash(&mut self, data_offset: MemPtr);
-    fn get_prev_tx_hash(&mut self, data_offset: MemPtr);
-    fn managed_sc_address(&mut self, destination_handle: i32);
-    fn managed_owner_address(&mut self, destination_handle: i32);
-    fn managed_caller(&mut self, destination_handle: i32);
-    fn managed_get_original_caller_addr(&mut self, destination_handle: i32);
-    fn managed_get_relayer_addr(&mut self, destination_handle: i32);
-    fn managed_signal_error(&mut self, err_handle: i32);
-    fn managed_write_log(&mut self, topics_handle: i32, data_handle: i32);
-    fn managed_get_original_tx_hash(&mut self, result_handle: i32);
-    fn managed_get_state_root_hash(&mut self, result_handle: i32);
-    fn managed_get_block_random_seed(&mut self, result_handle: i32);
-    fn managed_get_prev_block_random_seed(&mut self, result_handle: i32);
-    fn managed_get_return_data(&mut self, result_id: i32, result_handle: i32);
-    fn managed_get_multi_esdt_call_value(&mut self, multi_call_value_handle: i32);
-    fn managed_get_back_transfers(&mut self, esdt_transfers_value_handle: i32, egld_value_handle: i32);
-    fn managed_get_esdt_balance(&mut self, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32);
-    fn managed_get_esdt_token_data(&mut self, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32, properties_handle: i32, hash_handle: i32, name_handle: i32, attributes_handle: i32, creator_handle: i32, royalties_handle: i32, uris_handle: i32);
-    fn managed_async_call(&mut self, dest_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32);
-    fn managed_create_async_call(&mut self, dest_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, success_offset: MemPtr, success_length: MemLength, error_offset: MemPtr, error_length: MemLength, gas: i64, extra_gas_for_callback: i64, callback_closure_handle: i32) -> i32;
-    fn managed_get_callback_closure(&mut self, callback_closure_handle: i32);
-    fn managed_upgrade_from_source_contract(&mut self, dest_handle: i32, gas: i64, value_handle: i32, address_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_handle: i32);
-    fn managed_upgrade_contract(&mut self, dest_handle: i32, gas: i64, value_handle: i32, code_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_handle: i32);
-    fn managed_delete_contract(&mut self, dest_handle: i32, gas_limit: i64, arguments_handle: i32);
-    fn managed_deploy_from_source_contract(&mut self, gas: i64, value_handle: i32, address_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_address_handle: i32, result_handle: i32) -> i32;
-    fn managed_create_contract(&mut self, gas: i64, value_handle: i32, code_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_address_handle: i32, result_handle: i32) -> i32;
-    fn managed_execute_read_only(&mut self, gas: i64, address_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32;
-    fn managed_execute_on_same_context(&mut self, gas: i64, address_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32;
-    fn managed_execute_on_dest_context(&mut self, gas: i64, address_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32;
-    fn managed_multi_transfer_esdt_nft_execute(&mut self, dst_handle: i32, token_transfers_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32;
-    fn managed_multi_transfer_esdt_nft_execute_by_user(&mut self, user_handle: i32, dst_handle: i32, token_transfers_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32;
-    fn managed_transfer_value_execute(&mut self, dst_handle: i32, value_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32;
-    fn managed_is_esdt_frozen(&mut self, address_handle: i32, token_id_handle: i32, nonce: i64) -> i32;
-    fn managed_is_esdt_limited_transfer(&mut self, token_id_handle: i32) -> i32;
-    fn managed_is_esdt_paused(&mut self, token_id_handle: i32) -> i32;
-    fn managed_buffer_to_hex(&mut self, source_handle: i32, dest_handle: i32);
-    fn managed_get_code_metadata(&mut self, address_handle: i32, response_handle: i32);
-    fn managed_is_builtin_function(&mut self, function_name_handle: i32) -> i32;
-    fn big_float_new_from_parts(&mut self, integral_part: i32, fractional_part: i32, exponent: i32) -> i32;
-    fn big_float_new_from_frac(&mut self, numerator: i64, denominator: i64) -> i32;
-    fn big_float_new_from_sci(&mut self, significand: i64, exponent: i64) -> i32;
-    fn big_float_add(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
-    fn big_float_sub(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
-    fn big_float_mul(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
-    fn big_float_div(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
-    fn big_float_neg(&mut self, destination_handle: i32, op_handle: i32);
-    fn big_float_clone(&mut self, destination_handle: i32, op_handle: i32);
-    fn big_float_cmp(&mut self, op1_handle: i32, op2_handle: i32) -> i32;
-    fn big_float_abs(&mut self, destination_handle: i32, op_handle: i32);
-    fn big_float_sign(&mut self, op_handle: i32) -> i32;
-    fn big_float_sqrt(&mut self, destination_handle: i32, op_handle: i32);
-    fn big_float_pow(&mut self, destination_handle: i32, op_handle: i32, exponent: i32);
-    fn big_float_floor(&mut self, dest_big_int_handle: i32, op_handle: i32);
-    fn big_float_ceil(&mut self, dest_big_int_handle: i32, op_handle: i32);
-    fn big_float_truncate(&mut self, dest_big_int_handle: i32, op_handle: i32);
-    fn big_float_set_int64(&mut self, destination_handle: i32, value: i64);
-    fn big_float_is_int(&mut self, op_handle: i32) -> i32;
-    fn big_float_set_big_int(&mut self, destination_handle: i32, big_int_handle: i32);
-    fn big_float_get_const_pi(&mut self, destination_handle: i32);
-    fn big_float_get_const_e(&mut self, destination_handle: i32);
-    fn big_int_get_unsigned_argument(&mut self, id: i32, destination_handle: i32);
-    fn big_int_get_signed_argument(&mut self, id: i32, destination_handle: i32);
-    fn big_int_storage_store_unsigned(&mut self, key_offset: MemPtr, key_length: MemLength, source_handle: i32) -> i32;
-    fn big_int_storage_load_unsigned(&mut self, key_offset: MemPtr, key_length: MemLength, destination_handle: i32) -> i32;
-    fn big_int_get_call_value(&mut self, destination_handle: i32);
-    fn big_int_get_esdt_call_value(&mut self, destination: i32);
-    fn big_int_get_esdt_call_value_by_index(&mut self, destination_handle: i32, index: i32);
-    fn big_int_get_external_balance(&mut self, address_offset: MemPtr, result: i32);
-    fn big_int_get_esdt_external_balance(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, result_handle: i32);
-    fn big_int_new(&mut self, small_value: i64) -> i32;
-    fn big_int_unsigned_byte_length(&mut self, reference_handle: i32) -> i32;
-    fn big_int_signed_byte_length(&mut self, reference_handle: i32) -> i32;
-    fn big_int_get_unsigned_bytes(&mut self, reference_handle: i32, byte_offset: MemPtr) -> i32;
-    fn big_int_get_signed_bytes(&mut self, reference_handle: i32, byte_offset: MemPtr) -> i32;
-    fn big_int_set_unsigned_bytes(&mut self, destination_handle: i32, byte_offset: MemPtr, byte_length: MemLength);
-    fn big_int_set_signed_bytes(&mut self, destination_handle: i32, byte_offset: MemPtr, byte_length: MemLength);
-    fn big_int_is_int64(&mut self, destination_handle: i32) -> i32;
-    fn big_int_get_int64(&mut self, destination_handle: i32) -> i64;
-    fn big_int_set_int64(&mut self, destination_handle: i32, value: i64);
-    fn big_int_add(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
-    fn big_int_sub(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
-    fn big_int_mul(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
-    fn big_int_tdiv(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
-    fn big_int_tmod(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
-    fn big_int_ediv(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
-    fn big_int_emod(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
-    fn big_int_sqrt(&mut self, destination_handle: i32, op_handle: i32);
-    fn big_int_pow(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
-    fn big_int_log2(&mut self, op1_handle: i32) -> i32;
-    fn big_int_abs(&mut self, destination_handle: i32, op_handle: i32);
-    fn big_int_neg(&mut self, destination_handle: i32, op_handle: i32);
-    fn big_int_sign(&mut self, op_handle: i32) -> i32;
-    fn big_int_cmp(&mut self, op1_handle: i32, op2_handle: i32) -> i32;
-    fn big_int_not(&mut self, destination_handle: i32, op_handle: i32);
-    fn big_int_and(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
-    fn big_int_or(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
-    fn big_int_xor(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
-    fn big_int_shr(&mut self, destination_handle: i32, op_handle: i32, bits: i32);
-    fn big_int_shl(&mut self, destination_handle: i32, op_handle: i32, bits: i32);
-    fn big_int_finish_unsigned(&mut self, reference_handle: i32);
-    fn big_int_finish_signed(&mut self, reference_handle: i32);
-    fn big_int_to_string(&mut self, big_int_handle: i32, destination_handle: i32);
-    fn mbuffer_new(&mut self) -> i32;
-    fn mbuffer_new_from_bytes(&mut self, data_offset: MemPtr, data_length: MemLength) -> i32;
-    fn mbuffer_get_length(&mut self, m_buffer_handle: i32) -> i32;
-    fn mbuffer_get_bytes(&mut self, m_buffer_handle: i32, result_offset: MemPtr) -> i32;
-    fn mbuffer_get_byte_slice(&mut self, source_handle: i32, starting_position: i32, slice_length: i32, result_offset: MemPtr) -> i32;
-    fn mbuffer_copy_byte_slice(&mut self, source_handle: i32, starting_position: i32, slice_length: i32, destination_handle: i32) -> i32;
-    fn mbuffer_eq(&mut self, m_buffer_handle1: i32, m_buffer_handle2: i32) -> i32;
-    fn mbuffer_set_bytes(&mut self, m_buffer_handle: i32, data_offset: MemPtr, data_length: MemLength) -> i32;
-    fn mbuffer_set_byte_slice(&mut self, m_buffer_handle: i32, starting_position: i32, data_length: MemLength, data_offset: MemPtr) -> i32;
-    fn mbuffer_append(&mut self, accumulator_handle: i32, data_handle: i32) -> i32;
-    fn mbuffer_append_bytes(&mut self, accumulator_handle: i32, data_offset: MemPtr, data_length: MemLength) -> i32;
-    fn mbuffer_to_big_int_unsigned(&mut self, m_buffer_handle: i32, big_int_handle: i32) -> i32;
-    fn mbuffer_to_big_int_signed(&mut self, m_buffer_handle: i32, big_int_handle: i32) -> i32;
-    fn mbuffer_from_big_int_unsigned(&mut self, m_buffer_handle: i32, big_int_handle: i32) -> i32;
-    fn mbuffer_from_big_int_signed(&mut self, m_buffer_handle: i32, big_int_handle: i32) -> i32;
-    fn mbuffer_to_big_float(&mut self, m_buffer_handle: i32, big_float_handle: i32) -> i32;
-    fn mbuffer_from_big_float(&mut self, m_buffer_handle: i32, big_float_handle: i32) -> i32;
-    fn mbuffer_storage_store(&mut self, key_handle: i32, source_handle: i32) -> i32;
-    fn mbuffer_storage_load(&mut self, key_handle: i32, destination_handle: i32) -> i32;
-    fn mbuffer_storage_load_from_address(&mut self, address_handle: i32, key_handle: i32, destination_handle: i32);
-    fn mbuffer_get_argument(&mut self, id: i32, destination_handle: i32) -> i32;
-    fn mbuffer_finish(&mut self, source_handle: i32) -> i32;
-    fn mbuffer_set_random(&mut self, destination_handle: i32, length: i32) -> i32;
-    fn managed_map_new(&mut self) -> i32;
-    fn managed_map_put(&mut self, m_map_handle: i32, key_handle: i32, value_handle: i32) -> i32;
-    fn managed_map_get(&mut self, m_map_handle: i32, key_handle: i32, out_value_handle: i32) -> i32;
-    fn managed_map_remove(&mut self, m_map_handle: i32, key_handle: i32, out_value_handle: i32) -> i32;
-    fn managed_map_contains(&mut self, m_map_handle: i32, key_handle: i32) -> i32;
-    fn small_int_get_unsigned_argument(&mut self, id: i32) -> i64;
-    fn small_int_get_signed_argument(&mut self, id: i32) -> i64;
-    fn small_int_finish_unsigned(&mut self, value: i64);
-    fn small_int_finish_signed(&mut self, value: i64);
-    fn small_int_storage_store_unsigned(&mut self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32;
-    fn small_int_storage_store_signed(&mut self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32;
-    fn small_int_storage_load_unsigned(&mut self, key_offset: MemPtr, key_length: MemLength) -> i64;
-    fn small_int_storage_load_signed(&mut self, key_offset: MemPtr, key_length: MemLength) -> i64;
-    fn int64get_argument(&mut self, id: i32) -> i64;
-    fn int64finish(&mut self, value: i64);
-    fn int64storage_store(&mut self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32;
-    fn int64storage_load(&mut self, key_offset: MemPtr, key_length: MemLength) -> i64;
-    fn sha256(&mut self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32;
-    fn managed_sha256(&mut self, input_handle: i32, output_handle: i32) -> i32;
-    fn keccak256(&mut self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32;
-    fn managed_keccak256(&mut self, input_handle: i32, output_handle: i32) -> i32;
-    fn ripemd160(&mut self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32;
-    fn managed_ripemd160(&mut self, input_handle: i32, output_handle: i32) -> i32;
-    fn verify_bls(&mut self, key_offset: MemPtr, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32;
-    fn managed_verify_bls(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32;
-    fn verify_ed25519(&mut self, key_offset: MemPtr, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32;
-    fn managed_verify_ed25519(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32;
-    fn verify_custom_secp256k1(&mut self, key_offset: MemPtr, key_length: MemLength, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr, hash_type: i32) -> i32;
-    fn managed_verify_custom_secp256k1(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32, hash_type: i32) -> i32;
-    fn verify_secp256k1(&mut self, key_offset: MemPtr, key_length: MemLength, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32;
-    fn managed_verify_secp256k1(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32;
-    fn encode_secp256k1_der_signature(&mut self, r_offset: MemPtr, r_length: MemLength, s_offset: MemPtr, s_length: MemLength, sig_offset: MemPtr) -> i32;
-    fn managed_encode_secp256k1_der_signature(&mut self, r_handle: i32, s_handle: i32, sig_handle: i32) -> i32;
-    fn add_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, fst_point_xhandle: i32, fst_point_yhandle: i32, snd_point_xhandle: i32, snd_point_yhandle: i32);
-    fn double_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32);
-    fn is_on_curve_ec(&mut self, ec_handle: i32, point_xhandle: i32, point_yhandle: i32) -> i32;
-    fn scalar_base_mult_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32;
-    fn managed_scalar_base_mult_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32;
-    fn scalar_mult_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32, data_offset: MemPtr, length: MemLength) -> i32;
-    fn managed_scalar_mult_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32, data_handle: i32) -> i32;
-    fn marshal_ec(&mut self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32;
-    fn managed_marshal_ec(&mut self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_handle: i32) -> i32;
-    fn marshal_compressed_ec(&mut self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32;
-    fn managed_marshal_compressed_ec(&mut self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_handle: i32) -> i32;
-    fn unmarshal_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32;
-    fn managed_unmarshal_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32;
-    fn unmarshal_compressed_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32;
-    fn managed_unmarshal_compressed_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32;
-    fn generate_key_ec(&mut self, x_pub_key_handle: i32, y_pub_key_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32;
-    fn managed_generate_key_ec(&mut self, x_pub_key_handle: i32, y_pub_key_handle: i32, ec_handle: i32, result_handle: i32) -> i32;
-    fn create_ec(&mut self, data_offset: MemPtr, data_length: MemLength) -> i32;
-    fn managed_create_ec(&mut self, data_handle: i32) -> i32;
-    fn get_curve_length_ec(&mut self, ec_handle: i32) -> i32;
-    fn get_priv_key_byte_length_ec(&mut self, ec_handle: i32) -> i32;
-    fn elliptic_curve_get_values(&mut self, ec_handle: i32, field_order_handle: i32, base_point_order_handle: i32, eq_constant_handle: i32, x_base_point_handle: i32, y_base_point_handle: i32) -> i32;
-    fn managed_verify_secp256r1(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32;
-    fn managed_verify_blssignature_share(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32;
-    fn managed_verify_blsaggregated_signature(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32;
+    fn get_gas_left(&self) -> i64;
+    fn get_sc_address(&self, result_offset: MemPtr);
+    fn get_owner_address(&self, result_offset: MemPtr);
+    fn get_shard_of_address(&self, address_offset: MemPtr) -> i32;
+    fn is_smart_contract(&self, address_offset: MemPtr) -> i32;
+    fn signal_error(&self, message_offset: MemPtr, message_length: MemLength);
+    fn get_external_balance(&self, address_offset: MemPtr, result_offset: MemPtr);
+    fn get_block_hash(&self, nonce: i64, result_offset: MemPtr) -> i32;
+    fn get_esdt_balance(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, result_offset: MemPtr) -> i32;
+    fn get_esdt_nft_name_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32;
+    fn get_esdt_nft_attribute_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32;
+    fn get_esdt_nft_uri_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32;
+    fn get_esdt_token_data(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, value_handle: i32, properties_offset: MemPtr, hash_offset: MemPtr, name_offset: MemPtr, attributes_offset: MemPtr, creator_offset: MemPtr, royalties_handle: i32, uris_offset: MemPtr) -> i32;
+    fn get_esdt_local_roles(&self, token_id_handle: i32) -> i64;
+    fn validate_token_identifier(&self, token_id_handle: i32) -> i32;
+    fn transfer_value(&self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, length: MemLength) -> i32;
+    fn transfer_value_execute(&self, dest_offset: MemPtr, value_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32;
+    fn transfer_esdt_execute(&self, dest_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, value_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32;
+    fn transfer_esdt_nft_execute(&self, dest_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, value_offset: MemPtr, nonce: i64, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32;
+    fn multi_transfer_esdt_nft_execute(&self, dest_offset: MemPtr, num_token_transfers: i32, token_transfers_args_length_offset: MemPtr, token_transfer_data_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32;
+    fn create_async_call(&self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, data_length: MemLength, success_offset: MemPtr, success_length: MemLength, error_offset: MemPtr, error_length: MemLength, gas: i64, extra_gas_for_callback: i64) -> i32;
+    fn set_async_context_callback(&self, callback: MemPtr, callback_length: MemLength, data: MemPtr, data_length: MemLength, gas: i64) -> i32;
+    fn upgrade_contract(&self, dest_offset: MemPtr, gas_limit: i64, value_offset: MemPtr, code_offset: MemPtr, code_metadata_offset: MemPtr, length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr);
+    fn upgrade_from_source_contract(&self, dest_offset: MemPtr, gas_limit: i64, value_offset: MemPtr, source_contract_address_offset: MemPtr, code_metadata_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr);
+    fn delete_contract(&self, dest_offset: MemPtr, gas_limit: i64, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr);
+    fn async_call(&self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, length: MemLength);
+    fn get_argument_length(&self, id: i32) -> i32;
+    fn get_argument(&self, id: i32, arg_offset: MemPtr) -> i32;
+    fn get_function(&self, function_offset: MemPtr) -> i32;
+    fn get_num_arguments(&self) -> i32;
+    fn storage_store(&self, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr, data_length: MemLength) -> i32;
+    fn storage_load_length(&self, key_offset: MemPtr, key_length: MemLength) -> i32;
+    fn storage_load_from_address(&self, address_offset: MemPtr, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr) -> i32;
+    fn storage_load(&self, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr) -> i32;
+    fn set_storage_lock(&self, key_offset: MemPtr, key_length: MemLength, lock_timestamp: i64) -> i32;
+    fn get_storage_lock(&self, key_offset: MemPtr, key_length: MemLength) -> i64;
+    fn is_storage_locked(&self, key_offset: MemPtr, key_length: MemLength) -> i32;
+    fn clear_storage_lock(&self, key_offset: MemPtr, key_length: MemLength) -> i32;
+    fn get_caller(&self, result_offset: MemPtr);
+    fn check_no_payment(&self);
+    fn get_call_value(&self, result_offset: MemPtr) -> i32;
+    fn get_esdt_value(&self, result_offset: MemPtr) -> i32;
+    fn get_esdt_value_by_index(&self, result_offset: MemPtr, index: i32) -> i32;
+    fn get_esdt_token_name(&self, result_offset: MemPtr) -> i32;
+    fn get_esdt_token_name_by_index(&self, result_offset: MemPtr, index: i32) -> i32;
+    fn get_esdt_token_nonce(&self) -> i64;
+    fn get_esdt_token_nonce_by_index(&self, index: i32) -> i64;
+    fn get_current_esdt_nft_nonce(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength) -> i64;
+    fn get_esdt_token_type(&self) -> i32;
+    fn get_esdt_token_type_by_index(&self, index: i32) -> i32;
+    fn get_num_esdt_transfers(&self) -> i32;
+    fn get_call_value_token_name(&self, call_value_offset: MemPtr, token_name_offset: MemPtr) -> i32;
+    fn get_call_value_token_name_by_index(&self, call_value_offset: MemPtr, token_name_offset: MemPtr, index: i32) -> i32;
+    fn is_reserved_function_name(&self, name_handle: i32) -> i32;
+    fn write_log(&self, data_pointer: MemPtr, data_length: MemLength, topic_ptr: MemPtr, num_topics: i32);
+    fn write_event_log(&self, num_topics: i32, topic_lengths_offset: MemPtr, topic_offset: MemPtr, data_offset: MemPtr, data_length: MemLength);
+    fn get_block_timestamp(&self) -> i64;
+    fn get_block_nonce(&self) -> i64;
+    fn get_block_round(&self) -> i64;
+    fn get_block_epoch(&self) -> i64;
+    fn get_block_random_seed(&self, pointer: MemPtr);
+    fn get_state_root_hash(&self, pointer: MemPtr);
+    fn get_prev_block_timestamp(&self) -> i64;
+    fn get_prev_block_nonce(&self) -> i64;
+    fn get_prev_block_round(&self) -> i64;
+    fn get_prev_block_epoch(&self) -> i64;
+    fn get_prev_block_random_seed(&self, pointer: MemPtr);
+    fn finish(&self, pointer: MemPtr, length: MemLength);
+    fn execute_on_same_context(&self, gas_limit: i64, address_offset: MemPtr, value_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32;
+    fn execute_on_dest_context(&self, gas_limit: i64, address_offset: MemPtr, value_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32;
+    fn execute_read_only(&self, gas_limit: i64, address_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32;
+    fn create_contract(&self, gas_limit: i64, value_offset: MemPtr, code_offset: MemPtr, code_metadata_offset: MemPtr, length: MemLength, result_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32;
+    fn deploy_from_source_contract(&self, gas_limit: i64, value_offset: MemPtr, source_contract_address_offset: MemPtr, code_metadata_offset: MemPtr, result_address_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32;
+    fn get_num_return_data(&self) -> i32;
+    fn get_return_data_size(&self, result_id: i32) -> i32;
+    fn get_return_data(&self, result_id: i32, data_offset: MemPtr) -> i32;
+    fn clean_return_data(&self);
+    fn delete_from_return_data(&self, result_id: i32);
+    fn get_original_tx_hash(&self, data_offset: MemPtr);
+    fn get_current_tx_hash(&self, data_offset: MemPtr);
+    fn get_prev_tx_hash(&self, data_offset: MemPtr);
+    fn managed_sc_address(&self, destination_handle: i32);
+    fn managed_owner_address(&self, destination_handle: i32);
+    fn managed_caller(&self, destination_handle: i32);
+    fn managed_get_original_caller_addr(&self, destination_handle: i32);
+    fn managed_get_relayer_addr(&self, destination_handle: i32);
+    fn managed_signal_error(&self, err_handle: i32);
+    fn managed_write_log(&self, topics_handle: i32, data_handle: i32);
+    fn managed_get_original_tx_hash(&self, result_handle: i32);
+    fn managed_get_state_root_hash(&self, result_handle: i32);
+    fn managed_get_block_random_seed(&self, result_handle: i32);
+    fn managed_get_prev_block_random_seed(&self, result_handle: i32);
+    fn managed_get_return_data(&self, result_id: i32, result_handle: i32);
+    fn managed_get_multi_esdt_call_value(&self, multi_call_value_handle: i32);
+    fn managed_get_back_transfers(&self, esdt_transfers_value_handle: i32, egld_value_handle: i32);
+    fn managed_get_esdt_balance(&self, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32);
+    fn managed_get_esdt_token_data(&self, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32, properties_handle: i32, hash_handle: i32, name_handle: i32, attributes_handle: i32, creator_handle: i32, royalties_handle: i32, uris_handle: i32);
+    fn managed_async_call(&self, dest_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32);
+    fn managed_create_async_call(&self, dest_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, success_offset: MemPtr, success_length: MemLength, error_offset: MemPtr, error_length: MemLength, gas: i64, extra_gas_for_callback: i64, callback_closure_handle: i32) -> i32;
+    fn managed_get_callback_closure(&self, callback_closure_handle: i32);
+    fn managed_upgrade_from_source_contract(&self, dest_handle: i32, gas: i64, value_handle: i32, address_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_handle: i32);
+    fn managed_upgrade_contract(&self, dest_handle: i32, gas: i64, value_handle: i32, code_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_handle: i32);
+    fn managed_delete_contract(&self, dest_handle: i32, gas_limit: i64, arguments_handle: i32);
+    fn managed_deploy_from_source_contract(&self, gas: i64, value_handle: i32, address_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_address_handle: i32, result_handle: i32) -> i32;
+    fn managed_create_contract(&self, gas: i64, value_handle: i32, code_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_address_handle: i32, result_handle: i32) -> i32;
+    fn managed_execute_read_only(&self, gas: i64, address_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32;
+    fn managed_execute_on_same_context(&self, gas: i64, address_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32;
+    fn managed_execute_on_dest_context(&self, gas: i64, address_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32;
+    fn managed_multi_transfer_esdt_nft_execute(&self, dst_handle: i32, token_transfers_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32;
+    fn managed_multi_transfer_esdt_nft_execute_by_user(&self, user_handle: i32, dst_handle: i32, token_transfers_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32;
+    fn managed_transfer_value_execute(&self, dst_handle: i32, value_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32;
+    fn managed_is_esdt_frozen(&self, address_handle: i32, token_id_handle: i32, nonce: i64) -> i32;
+    fn managed_is_esdt_limited_transfer(&self, token_id_handle: i32) -> i32;
+    fn managed_is_esdt_paused(&self, token_id_handle: i32) -> i32;
+    fn managed_buffer_to_hex(&self, source_handle: i32, dest_handle: i32);
+    fn managed_get_code_metadata(&self, address_handle: i32, response_handle: i32);
+    fn managed_is_builtin_function(&self, function_name_handle: i32) -> i32;
+    fn big_float_new_from_parts(&self, integral_part: i32, fractional_part: i32, exponent: i32) -> i32;
+    fn big_float_new_from_frac(&self, numerator: i64, denominator: i64) -> i32;
+    fn big_float_new_from_sci(&self, significand: i64, exponent: i64) -> i32;
+    fn big_float_add(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
+    fn big_float_sub(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
+    fn big_float_mul(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
+    fn big_float_div(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
+    fn big_float_neg(&self, destination_handle: i32, op_handle: i32);
+    fn big_float_clone(&self, destination_handle: i32, op_handle: i32);
+    fn big_float_cmp(&self, op1_handle: i32, op2_handle: i32) -> i32;
+    fn big_float_abs(&self, destination_handle: i32, op_handle: i32);
+    fn big_float_sign(&self, op_handle: i32) -> i32;
+    fn big_float_sqrt(&self, destination_handle: i32, op_handle: i32);
+    fn big_float_pow(&self, destination_handle: i32, op_handle: i32, exponent: i32);
+    fn big_float_floor(&self, dest_big_int_handle: i32, op_handle: i32);
+    fn big_float_ceil(&self, dest_big_int_handle: i32, op_handle: i32);
+    fn big_float_truncate(&self, dest_big_int_handle: i32, op_handle: i32);
+    fn big_float_set_int64(&self, destination_handle: i32, value: i64);
+    fn big_float_is_int(&self, op_handle: i32) -> i32;
+    fn big_float_set_big_int(&self, destination_handle: i32, big_int_handle: i32);
+    fn big_float_get_const_pi(&self, destination_handle: i32);
+    fn big_float_get_const_e(&self, destination_handle: i32);
+    fn big_int_get_unsigned_argument(&self, id: i32, destination_handle: i32);
+    fn big_int_get_signed_argument(&self, id: i32, destination_handle: i32);
+    fn big_int_storage_store_unsigned(&self, key_offset: MemPtr, key_length: MemLength, source_handle: i32) -> i32;
+    fn big_int_storage_load_unsigned(&self, key_offset: MemPtr, key_length: MemLength, destination_handle: i32) -> i32;
+    fn big_int_get_call_value(&self, destination_handle: i32);
+    fn big_int_get_esdt_call_value(&self, destination: i32);
+    fn big_int_get_esdt_call_value_by_index(&self, destination_handle: i32, index: i32);
+    fn big_int_get_external_balance(&self, address_offset: MemPtr, result: i32);
+    fn big_int_get_esdt_external_balance(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, result_handle: i32);
+    fn big_int_new(&self, small_value: i64) -> i32;
+    fn big_int_unsigned_byte_length(&self, reference_handle: i32) -> i32;
+    fn big_int_signed_byte_length(&self, reference_handle: i32) -> i32;
+    fn big_int_get_unsigned_bytes(&self, reference_handle: i32, byte_offset: MemPtr) -> i32;
+    fn big_int_get_signed_bytes(&self, reference_handle: i32, byte_offset: MemPtr) -> i32;
+    fn big_int_set_unsigned_bytes(&self, destination_handle: i32, byte_offset: MemPtr, byte_length: MemLength);
+    fn big_int_set_signed_bytes(&self, destination_handle: i32, byte_offset: MemPtr, byte_length: MemLength);
+    fn big_int_is_int64(&self, destination_handle: i32) -> i32;
+    fn big_int_get_int64(&self, destination_handle: i32) -> i64;
+    fn big_int_set_int64(&self, destination_handle: i32, value: i64);
+    fn big_int_add(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
+    fn big_int_sub(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
+    fn big_int_mul(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
+    fn big_int_tdiv(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
+    fn big_int_tmod(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
+    fn big_int_ediv(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
+    fn big_int_emod(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
+    fn big_int_sqrt(&self, destination_handle: i32, op_handle: i32);
+    fn big_int_pow(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
+    fn big_int_log2(&self, op1_handle: i32) -> i32;
+    fn big_int_abs(&self, destination_handle: i32, op_handle: i32);
+    fn big_int_neg(&self, destination_handle: i32, op_handle: i32);
+    fn big_int_sign(&self, op_handle: i32) -> i32;
+    fn big_int_cmp(&self, op1_handle: i32, op2_handle: i32) -> i32;
+    fn big_int_not(&self, destination_handle: i32, op_handle: i32);
+    fn big_int_and(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
+    fn big_int_or(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
+    fn big_int_xor(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32);
+    fn big_int_shr(&self, destination_handle: i32, op_handle: i32, bits: i32);
+    fn big_int_shl(&self, destination_handle: i32, op_handle: i32, bits: i32);
+    fn big_int_finish_unsigned(&self, reference_handle: i32);
+    fn big_int_finish_signed(&self, reference_handle: i32);
+    fn big_int_to_string(&self, big_int_handle: i32, destination_handle: i32);
+    fn mbuffer_new(&self) -> i32;
+    fn mbuffer_new_from_bytes(&self, data_offset: MemPtr, data_length: MemLength) -> i32;
+    fn mbuffer_get_length(&self, m_buffer_handle: i32) -> i32;
+    fn mbuffer_get_bytes(&self, m_buffer_handle: i32, result_offset: MemPtr) -> i32;
+    fn mbuffer_get_byte_slice(&self, source_handle: i32, starting_position: i32, slice_length: i32, result_offset: MemPtr) -> i32;
+    fn mbuffer_copy_byte_slice(&self, source_handle: i32, starting_position: i32, slice_length: i32, destination_handle: i32) -> i32;
+    fn mbuffer_eq(&self, m_buffer_handle1: i32, m_buffer_handle2: i32) -> i32;
+    fn mbuffer_set_bytes(&self, m_buffer_handle: i32, data_offset: MemPtr, data_length: MemLength) -> i32;
+    fn mbuffer_set_byte_slice(&self, m_buffer_handle: i32, starting_position: i32, data_length: MemLength, data_offset: MemPtr) -> i32;
+    fn mbuffer_append(&self, accumulator_handle: i32, data_handle: i32) -> i32;
+    fn mbuffer_append_bytes(&self, accumulator_handle: i32, data_offset: MemPtr, data_length: MemLength) -> i32;
+    fn mbuffer_to_big_int_unsigned(&self, m_buffer_handle: i32, big_int_handle: i32) -> i32;
+    fn mbuffer_to_big_int_signed(&self, m_buffer_handle: i32, big_int_handle: i32) -> i32;
+    fn mbuffer_from_big_int_unsigned(&self, m_buffer_handle: i32, big_int_handle: i32) -> i32;
+    fn mbuffer_from_big_int_signed(&self, m_buffer_handle: i32, big_int_handle: i32) -> i32;
+    fn mbuffer_to_big_float(&self, m_buffer_handle: i32, big_float_handle: i32) -> i32;
+    fn mbuffer_from_big_float(&self, m_buffer_handle: i32, big_float_handle: i32) -> i32;
+    fn mbuffer_storage_store(&self, key_handle: i32, source_handle: i32) -> i32;
+    fn mbuffer_storage_load(&self, key_handle: i32, destination_handle: i32) -> i32;
+    fn mbuffer_storage_load_from_address(&self, address_handle: i32, key_handle: i32, destination_handle: i32);
+    fn mbuffer_get_argument(&self, id: i32, destination_handle: i32) -> i32;
+    fn mbuffer_finish(&self, source_handle: i32) -> i32;
+    fn mbuffer_set_random(&self, destination_handle: i32, length: i32) -> i32;
+    fn managed_map_new(&self) -> i32;
+    fn managed_map_put(&self, m_map_handle: i32, key_handle: i32, value_handle: i32) -> i32;
+    fn managed_map_get(&self, m_map_handle: i32, key_handle: i32, out_value_handle: i32) -> i32;
+    fn managed_map_remove(&self, m_map_handle: i32, key_handle: i32, out_value_handle: i32) -> i32;
+    fn managed_map_contains(&self, m_map_handle: i32, key_handle: i32) -> i32;
+    fn small_int_get_unsigned_argument(&self, id: i32) -> i64;
+    fn small_int_get_signed_argument(&self, id: i32) -> i64;
+    fn small_int_finish_unsigned(&self, value: i64);
+    fn small_int_finish_signed(&self, value: i64);
+    fn small_int_storage_store_unsigned(&self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32;
+    fn small_int_storage_store_signed(&self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32;
+    fn small_int_storage_load_unsigned(&self, key_offset: MemPtr, key_length: MemLength) -> i64;
+    fn small_int_storage_load_signed(&self, key_offset: MemPtr, key_length: MemLength) -> i64;
+    fn int64get_argument(&self, id: i32) -> i64;
+    fn int64finish(&self, value: i64);
+    fn int64storage_store(&self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32;
+    fn int64storage_load(&self, key_offset: MemPtr, key_length: MemLength) -> i64;
+    fn sha256(&self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32;
+    fn managed_sha256(&self, input_handle: i32, output_handle: i32) -> i32;
+    fn keccak256(&self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32;
+    fn managed_keccak256(&self, input_handle: i32, output_handle: i32) -> i32;
+    fn ripemd160(&self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32;
+    fn managed_ripemd160(&self, input_handle: i32, output_handle: i32) -> i32;
+    fn verify_bls(&self, key_offset: MemPtr, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32;
+    fn managed_verify_bls(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32;
+    fn verify_ed25519(&self, key_offset: MemPtr, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32;
+    fn managed_verify_ed25519(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32;
+    fn verify_custom_secp256k1(&self, key_offset: MemPtr, key_length: MemLength, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr, hash_type: i32) -> i32;
+    fn managed_verify_custom_secp256k1(&self, key_handle: i32, message_handle: i32, sig_handle: i32, hash_type: i32) -> i32;
+    fn verify_secp256k1(&self, key_offset: MemPtr, key_length: MemLength, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32;
+    fn managed_verify_secp256k1(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32;
+    fn encode_secp256k1_der_signature(&self, r_offset: MemPtr, r_length: MemLength, s_offset: MemPtr, s_length: MemLength, sig_offset: MemPtr) -> i32;
+    fn managed_encode_secp256k1_der_signature(&self, r_handle: i32, s_handle: i32, sig_handle: i32) -> i32;
+    fn add_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, fst_point_xhandle: i32, fst_point_yhandle: i32, snd_point_xhandle: i32, snd_point_yhandle: i32);
+    fn double_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32);
+    fn is_on_curve_ec(&self, ec_handle: i32, point_xhandle: i32, point_yhandle: i32) -> i32;
+    fn scalar_base_mult_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32;
+    fn managed_scalar_base_mult_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32;
+    fn scalar_mult_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32, data_offset: MemPtr, length: MemLength) -> i32;
+    fn managed_scalar_mult_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32, data_handle: i32) -> i32;
+    fn marshal_ec(&self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32;
+    fn managed_marshal_ec(&self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_handle: i32) -> i32;
+    fn marshal_compressed_ec(&self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32;
+    fn managed_marshal_compressed_ec(&self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_handle: i32) -> i32;
+    fn unmarshal_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32;
+    fn managed_unmarshal_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32;
+    fn unmarshal_compressed_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32;
+    fn managed_unmarshal_compressed_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32;
+    fn generate_key_ec(&self, x_pub_key_handle: i32, y_pub_key_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32;
+    fn managed_generate_key_ec(&self, x_pub_key_handle: i32, y_pub_key_handle: i32, ec_handle: i32, result_handle: i32) -> i32;
+    fn create_ec(&self, data_offset: MemPtr, data_length: MemLength) -> i32;
+    fn managed_create_ec(&self, data_handle: i32) -> i32;
+    fn get_curve_length_ec(&self, ec_handle: i32) -> i32;
+    fn get_priv_key_byte_length_ec(&self, ec_handle: i32) -> i32;
+    fn elliptic_curve_get_values(&self, ec_handle: i32, field_order_handle: i32, base_point_order_handle: i32, eq_constant_handle: i32, x_base_point_handle: i32, y_base_point_handle: i32) -> i32;
+    fn managed_verify_secp256r1(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32;
+    fn managed_verify_blssignature_share(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32;
+    fn managed_verify_blsaggregated_signature(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32;
 }
 
 /// Dummy implementation for VMHooks. Can be used as placeholder, or in tests.
@@ -287,1216 +287,1216 @@ impl VMHooksLegacy for VMHooksLegacyDefault {
     fn set_vm_hooks_ptr(&mut self, _vm_hooks_ptr: *mut c_void) {
     }
 
-    fn get_gas_left(&mut self) -> i64 {
+    fn get_gas_left(&self) -> i64 {
         println!("Called: get_gas_left");
         0
     }
 
-    fn get_sc_address(&mut self, result_offset: MemPtr) {
+    fn get_sc_address(&self, result_offset: MemPtr) {
         println!("Called: get_sc_address");
     }
 
-    fn get_owner_address(&mut self, result_offset: MemPtr) {
+    fn get_owner_address(&self, result_offset: MemPtr) {
         println!("Called: get_owner_address");
     }
 
-    fn get_shard_of_address(&mut self, address_offset: MemPtr) -> i32 {
+    fn get_shard_of_address(&self, address_offset: MemPtr) -> i32 {
         println!("Called: get_shard_of_address");
         0
     }
 
-    fn is_smart_contract(&mut self, address_offset: MemPtr) -> i32 {
+    fn is_smart_contract(&self, address_offset: MemPtr) -> i32 {
         println!("Called: is_smart_contract");
         0
     }
 
-    fn signal_error(&mut self, message_offset: MemPtr, message_length: MemLength) {
+    fn signal_error(&self, message_offset: MemPtr, message_length: MemLength) {
         println!("Called: signal_error");
     }
 
-    fn get_external_balance(&mut self, address_offset: MemPtr, result_offset: MemPtr) {
+    fn get_external_balance(&self, address_offset: MemPtr, result_offset: MemPtr) {
         println!("Called: get_external_balance");
     }
 
-    fn get_block_hash(&mut self, nonce: i64, result_offset: MemPtr) -> i32 {
+    fn get_block_hash(&self, nonce: i64, result_offset: MemPtr) -> i32 {
         println!("Called: get_block_hash");
         0
     }
 
-    fn get_esdt_balance(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, result_offset: MemPtr) -> i32 {
+    fn get_esdt_balance(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, result_offset: MemPtr) -> i32 {
         println!("Called: get_esdt_balance");
         0
     }
 
-    fn get_esdt_nft_name_length(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
+    fn get_esdt_nft_name_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
         println!("Called: get_esdt_nft_name_length");
         0
     }
 
-    fn get_esdt_nft_attribute_length(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
+    fn get_esdt_nft_attribute_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
         println!("Called: get_esdt_nft_attribute_length");
         0
     }
 
-    fn get_esdt_nft_uri_length(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
+    fn get_esdt_nft_uri_length(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64) -> i32 {
         println!("Called: get_esdt_nft_uri_length");
         0
     }
 
-    fn get_esdt_token_data(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, value_handle: i32, properties_offset: MemPtr, hash_offset: MemPtr, name_offset: MemPtr, attributes_offset: MemPtr, creator_offset: MemPtr, royalties_handle: i32, uris_offset: MemPtr) -> i32 {
+    fn get_esdt_token_data(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, value_handle: i32, properties_offset: MemPtr, hash_offset: MemPtr, name_offset: MemPtr, attributes_offset: MemPtr, creator_offset: MemPtr, royalties_handle: i32, uris_offset: MemPtr) -> i32 {
         println!("Called: get_esdt_token_data");
         0
     }
 
-    fn get_esdt_local_roles(&mut self, token_id_handle: i32) -> i64 {
+    fn get_esdt_local_roles(&self, token_id_handle: i32) -> i64 {
         println!("Called: get_esdt_local_roles");
         0
     }
 
-    fn validate_token_identifier(&mut self, token_id_handle: i32) -> i32 {
+    fn validate_token_identifier(&self, token_id_handle: i32) -> i32 {
         println!("Called: validate_token_identifier");
         0
     }
 
-    fn transfer_value(&mut self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, length: MemLength) -> i32 {
+    fn transfer_value(&self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, length: MemLength) -> i32 {
         println!("Called: transfer_value");
         0
     }
 
-    fn transfer_value_execute(&mut self, dest_offset: MemPtr, value_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+    fn transfer_value_execute(&self, dest_offset: MemPtr, value_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
         println!("Called: transfer_value_execute");
         0
     }
 
-    fn transfer_esdt_execute(&mut self, dest_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, value_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+    fn transfer_esdt_execute(&self, dest_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, value_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
         println!("Called: transfer_esdt_execute");
         0
     }
 
-    fn transfer_esdt_nft_execute(&mut self, dest_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, value_offset: MemPtr, nonce: i64, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+    fn transfer_esdt_nft_execute(&self, dest_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, value_offset: MemPtr, nonce: i64, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
         println!("Called: transfer_esdt_nft_execute");
         0
     }
 
-    fn multi_transfer_esdt_nft_execute(&mut self, dest_offset: MemPtr, num_token_transfers: i32, token_transfers_args_length_offset: MemPtr, token_transfer_data_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+    fn multi_transfer_esdt_nft_execute(&self, dest_offset: MemPtr, num_token_transfers: i32, token_transfers_args_length_offset: MemPtr, token_transfer_data_offset: MemPtr, gas_limit: i64, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
         println!("Called: multi_transfer_esdt_nft_execute");
         0
     }
 
-    fn create_async_call(&mut self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, data_length: MemLength, success_offset: MemPtr, success_length: MemLength, error_offset: MemPtr, error_length: MemLength, gas: i64, extra_gas_for_callback: i64) -> i32 {
+    fn create_async_call(&self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, data_length: MemLength, success_offset: MemPtr, success_length: MemLength, error_offset: MemPtr, error_length: MemLength, gas: i64, extra_gas_for_callback: i64) -> i32 {
         println!("Called: create_async_call");
         0
     }
 
-    fn set_async_context_callback(&mut self, callback: MemPtr, callback_length: MemLength, data: MemPtr, data_length: MemLength, gas: i64) -> i32 {
+    fn set_async_context_callback(&self, callback: MemPtr, callback_length: MemLength, data: MemPtr, data_length: MemLength, gas: i64) -> i32 {
         println!("Called: set_async_context_callback");
         0
     }
 
-    fn upgrade_contract(&mut self, dest_offset: MemPtr, gas_limit: i64, value_offset: MemPtr, code_offset: MemPtr, code_metadata_offset: MemPtr, length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) {
+    fn upgrade_contract(&self, dest_offset: MemPtr, gas_limit: i64, value_offset: MemPtr, code_offset: MemPtr, code_metadata_offset: MemPtr, length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) {
         println!("Called: upgrade_contract");
     }
 
-    fn upgrade_from_source_contract(&mut self, dest_offset: MemPtr, gas_limit: i64, value_offset: MemPtr, source_contract_address_offset: MemPtr, code_metadata_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) {
+    fn upgrade_from_source_contract(&self, dest_offset: MemPtr, gas_limit: i64, value_offset: MemPtr, source_contract_address_offset: MemPtr, code_metadata_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) {
         println!("Called: upgrade_from_source_contract");
     }
 
-    fn delete_contract(&mut self, dest_offset: MemPtr, gas_limit: i64, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) {
+    fn delete_contract(&self, dest_offset: MemPtr, gas_limit: i64, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) {
         println!("Called: delete_contract");
     }
 
-    fn async_call(&mut self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, length: MemLength) {
+    fn async_call(&self, dest_offset: MemPtr, value_offset: MemPtr, data_offset: MemPtr, length: MemLength) {
         println!("Called: async_call");
     }
 
-    fn get_argument_length(&mut self, id: i32) -> i32 {
+    fn get_argument_length(&self, id: i32) -> i32 {
         println!("Called: get_argument_length");
         0
     }
 
-    fn get_argument(&mut self, id: i32, arg_offset: MemPtr) -> i32 {
+    fn get_argument(&self, id: i32, arg_offset: MemPtr) -> i32 {
         println!("Called: get_argument");
         0
     }
 
-    fn get_function(&mut self, function_offset: MemPtr) -> i32 {
+    fn get_function(&self, function_offset: MemPtr) -> i32 {
         println!("Called: get_function");
         0
     }
 
-    fn get_num_arguments(&mut self) -> i32 {
+    fn get_num_arguments(&self) -> i32 {
         println!("Called: get_num_arguments");
         0
     }
 
-    fn storage_store(&mut self, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr, data_length: MemLength) -> i32 {
+    fn storage_store(&self, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr, data_length: MemLength) -> i32 {
         println!("Called: storage_store");
         0
     }
 
-    fn storage_load_length(&mut self, key_offset: MemPtr, key_length: MemLength) -> i32 {
+    fn storage_load_length(&self, key_offset: MemPtr, key_length: MemLength) -> i32 {
         println!("Called: storage_load_length");
         0
     }
 
-    fn storage_load_from_address(&mut self, address_offset: MemPtr, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr) -> i32 {
+    fn storage_load_from_address(&self, address_offset: MemPtr, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr) -> i32 {
         println!("Called: storage_load_from_address");
         0
     }
 
-    fn storage_load(&mut self, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr) -> i32 {
+    fn storage_load(&self, key_offset: MemPtr, key_length: MemLength, data_offset: MemPtr) -> i32 {
         println!("Called: storage_load");
         0
     }
 
-    fn set_storage_lock(&mut self, key_offset: MemPtr, key_length: MemLength, lock_timestamp: i64) -> i32 {
+    fn set_storage_lock(&self, key_offset: MemPtr, key_length: MemLength, lock_timestamp: i64) -> i32 {
         println!("Called: set_storage_lock");
         0
     }
 
-    fn get_storage_lock(&mut self, key_offset: MemPtr, key_length: MemLength) -> i64 {
+    fn get_storage_lock(&self, key_offset: MemPtr, key_length: MemLength) -> i64 {
         println!("Called: get_storage_lock");
         0
     }
 
-    fn is_storage_locked(&mut self, key_offset: MemPtr, key_length: MemLength) -> i32 {
+    fn is_storage_locked(&self, key_offset: MemPtr, key_length: MemLength) -> i32 {
         println!("Called: is_storage_locked");
         0
     }
 
-    fn clear_storage_lock(&mut self, key_offset: MemPtr, key_length: MemLength) -> i32 {
+    fn clear_storage_lock(&self, key_offset: MemPtr, key_length: MemLength) -> i32 {
         println!("Called: clear_storage_lock");
         0
     }
 
-    fn get_caller(&mut self, result_offset: MemPtr) {
+    fn get_caller(&self, result_offset: MemPtr) {
         println!("Called: get_caller");
     }
 
-    fn check_no_payment(&mut self) {
+    fn check_no_payment(&self) {
         println!("Called: check_no_payment");
     }
 
-    fn get_call_value(&mut self, result_offset: MemPtr) -> i32 {
+    fn get_call_value(&self, result_offset: MemPtr) -> i32 {
         println!("Called: get_call_value");
         0
     }
 
-    fn get_esdt_value(&mut self, result_offset: MemPtr) -> i32 {
+    fn get_esdt_value(&self, result_offset: MemPtr) -> i32 {
         println!("Called: get_esdt_value");
         0
     }
 
-    fn get_esdt_value_by_index(&mut self, result_offset: MemPtr, index: i32) -> i32 {
+    fn get_esdt_value_by_index(&self, result_offset: MemPtr, index: i32) -> i32 {
         println!("Called: get_esdt_value_by_index");
         0
     }
 
-    fn get_esdt_token_name(&mut self, result_offset: MemPtr) -> i32 {
+    fn get_esdt_token_name(&self, result_offset: MemPtr) -> i32 {
         println!("Called: get_esdt_token_name");
         0
     }
 
-    fn get_esdt_token_name_by_index(&mut self, result_offset: MemPtr, index: i32) -> i32 {
+    fn get_esdt_token_name_by_index(&self, result_offset: MemPtr, index: i32) -> i32 {
         println!("Called: get_esdt_token_name_by_index");
         0
     }
 
-    fn get_esdt_token_nonce(&mut self) -> i64 {
+    fn get_esdt_token_nonce(&self) -> i64 {
         println!("Called: get_esdt_token_nonce");
         0
     }
 
-    fn get_esdt_token_nonce_by_index(&mut self, index: i32) -> i64 {
+    fn get_esdt_token_nonce_by_index(&self, index: i32) -> i64 {
         println!("Called: get_esdt_token_nonce_by_index");
         0
     }
 
-    fn get_current_esdt_nft_nonce(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength) -> i64 {
+    fn get_current_esdt_nft_nonce(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength) -> i64 {
         println!("Called: get_current_esdt_nft_nonce");
         0
     }
 
-    fn get_esdt_token_type(&mut self) -> i32 {
+    fn get_esdt_token_type(&self) -> i32 {
         println!("Called: get_esdt_token_type");
         0
     }
 
-    fn get_esdt_token_type_by_index(&mut self, index: i32) -> i32 {
+    fn get_esdt_token_type_by_index(&self, index: i32) -> i32 {
         println!("Called: get_esdt_token_type_by_index");
         0
     }
 
-    fn get_num_esdt_transfers(&mut self) -> i32 {
+    fn get_num_esdt_transfers(&self) -> i32 {
         println!("Called: get_num_esdt_transfers");
         0
     }
 
-    fn get_call_value_token_name(&mut self, call_value_offset: MemPtr, token_name_offset: MemPtr) -> i32 {
+    fn get_call_value_token_name(&self, call_value_offset: MemPtr, token_name_offset: MemPtr) -> i32 {
         println!("Called: get_call_value_token_name");
         0
     }
 
-    fn get_call_value_token_name_by_index(&mut self, call_value_offset: MemPtr, token_name_offset: MemPtr, index: i32) -> i32 {
+    fn get_call_value_token_name_by_index(&self, call_value_offset: MemPtr, token_name_offset: MemPtr, index: i32) -> i32 {
         println!("Called: get_call_value_token_name_by_index");
         0
     }
 
-    fn is_reserved_function_name(&mut self, name_handle: i32) -> i32 {
+    fn is_reserved_function_name(&self, name_handle: i32) -> i32 {
         println!("Called: is_reserved_function_name");
         0
     }
 
-    fn write_log(&mut self, data_pointer: MemPtr, data_length: MemLength, topic_ptr: MemPtr, num_topics: i32) {
+    fn write_log(&self, data_pointer: MemPtr, data_length: MemLength, topic_ptr: MemPtr, num_topics: i32) {
         println!("Called: write_log");
     }
 
-    fn write_event_log(&mut self, num_topics: i32, topic_lengths_offset: MemPtr, topic_offset: MemPtr, data_offset: MemPtr, data_length: MemLength) {
+    fn write_event_log(&self, num_topics: i32, topic_lengths_offset: MemPtr, topic_offset: MemPtr, data_offset: MemPtr, data_length: MemLength) {
         println!("Called: write_event_log");
     }
 
-    fn get_block_timestamp(&mut self) -> i64 {
+    fn get_block_timestamp(&self) -> i64 {
         println!("Called: get_block_timestamp");
         0
     }
 
-    fn get_block_nonce(&mut self) -> i64 {
+    fn get_block_nonce(&self) -> i64 {
         println!("Called: get_block_nonce");
         0
     }
 
-    fn get_block_round(&mut self) -> i64 {
+    fn get_block_round(&self) -> i64 {
         println!("Called: get_block_round");
         0
     }
 
-    fn get_block_epoch(&mut self) -> i64 {
+    fn get_block_epoch(&self) -> i64 {
         println!("Called: get_block_epoch");
         0
     }
 
-    fn get_block_random_seed(&mut self, pointer: MemPtr) {
+    fn get_block_random_seed(&self, pointer: MemPtr) {
         println!("Called: get_block_random_seed");
     }
 
-    fn get_state_root_hash(&mut self, pointer: MemPtr) {
+    fn get_state_root_hash(&self, pointer: MemPtr) {
         println!("Called: get_state_root_hash");
     }
 
-    fn get_prev_block_timestamp(&mut self) -> i64 {
+    fn get_prev_block_timestamp(&self) -> i64 {
         println!("Called: get_prev_block_timestamp");
         0
     }
 
-    fn get_prev_block_nonce(&mut self) -> i64 {
+    fn get_prev_block_nonce(&self) -> i64 {
         println!("Called: get_prev_block_nonce");
         0
     }
 
-    fn get_prev_block_round(&mut self) -> i64 {
+    fn get_prev_block_round(&self) -> i64 {
         println!("Called: get_prev_block_round");
         0
     }
 
-    fn get_prev_block_epoch(&mut self) -> i64 {
+    fn get_prev_block_epoch(&self) -> i64 {
         println!("Called: get_prev_block_epoch");
         0
     }
 
-    fn get_prev_block_random_seed(&mut self, pointer: MemPtr) {
+    fn get_prev_block_random_seed(&self, pointer: MemPtr) {
         println!("Called: get_prev_block_random_seed");
     }
 
-    fn finish(&mut self, pointer: MemPtr, length: MemLength) {
+    fn finish(&self, pointer: MemPtr, length: MemLength) {
         println!("Called: finish");
     }
 
-    fn execute_on_same_context(&mut self, gas_limit: i64, address_offset: MemPtr, value_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+    fn execute_on_same_context(&self, gas_limit: i64, address_offset: MemPtr, value_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
         println!("Called: execute_on_same_context");
         0
     }
 
-    fn execute_on_dest_context(&mut self, gas_limit: i64, address_offset: MemPtr, value_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+    fn execute_on_dest_context(&self, gas_limit: i64, address_offset: MemPtr, value_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
         println!("Called: execute_on_dest_context");
         0
     }
 
-    fn execute_read_only(&mut self, gas_limit: i64, address_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+    fn execute_read_only(&self, gas_limit: i64, address_offset: MemPtr, function_offset: MemPtr, function_length: MemLength, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
         println!("Called: execute_read_only");
         0
     }
 
-    fn create_contract(&mut self, gas_limit: i64, value_offset: MemPtr, code_offset: MemPtr, code_metadata_offset: MemPtr, length: MemLength, result_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+    fn create_contract(&self, gas_limit: i64, value_offset: MemPtr, code_offset: MemPtr, code_metadata_offset: MemPtr, length: MemLength, result_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
         println!("Called: create_contract");
         0
     }
 
-    fn deploy_from_source_contract(&mut self, gas_limit: i64, value_offset: MemPtr, source_contract_address_offset: MemPtr, code_metadata_offset: MemPtr, result_address_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
+    fn deploy_from_source_contract(&self, gas_limit: i64, value_offset: MemPtr, source_contract_address_offset: MemPtr, code_metadata_offset: MemPtr, result_address_offset: MemPtr, num_arguments: i32, arguments_length_offset: MemPtr, data_offset: MemPtr) -> i32 {
         println!("Called: deploy_from_source_contract");
         0
     }
 
-    fn get_num_return_data(&mut self) -> i32 {
+    fn get_num_return_data(&self) -> i32 {
         println!("Called: get_num_return_data");
         0
     }
 
-    fn get_return_data_size(&mut self, result_id: i32) -> i32 {
+    fn get_return_data_size(&self, result_id: i32) -> i32 {
         println!("Called: get_return_data_size");
         0
     }
 
-    fn get_return_data(&mut self, result_id: i32, data_offset: MemPtr) -> i32 {
+    fn get_return_data(&self, result_id: i32, data_offset: MemPtr) -> i32 {
         println!("Called: get_return_data");
         0
     }
 
-    fn clean_return_data(&mut self) {
+    fn clean_return_data(&self) {
         println!("Called: clean_return_data");
     }
 
-    fn delete_from_return_data(&mut self, result_id: i32) {
+    fn delete_from_return_data(&self, result_id: i32) {
         println!("Called: delete_from_return_data");
     }
 
-    fn get_original_tx_hash(&mut self, data_offset: MemPtr) {
+    fn get_original_tx_hash(&self, data_offset: MemPtr) {
         println!("Called: get_original_tx_hash");
     }
 
-    fn get_current_tx_hash(&mut self, data_offset: MemPtr) {
+    fn get_current_tx_hash(&self, data_offset: MemPtr) {
         println!("Called: get_current_tx_hash");
     }
 
-    fn get_prev_tx_hash(&mut self, data_offset: MemPtr) {
+    fn get_prev_tx_hash(&self, data_offset: MemPtr) {
         println!("Called: get_prev_tx_hash");
     }
 
-    fn managed_sc_address(&mut self, destination_handle: i32) {
+    fn managed_sc_address(&self, destination_handle: i32) {
         println!("Called: managed_sc_address");
     }
 
-    fn managed_owner_address(&mut self, destination_handle: i32) {
+    fn managed_owner_address(&self, destination_handle: i32) {
         println!("Called: managed_owner_address");
     }
 
-    fn managed_caller(&mut self, destination_handle: i32) {
+    fn managed_caller(&self, destination_handle: i32) {
         println!("Called: managed_caller");
     }
 
-    fn managed_get_original_caller_addr(&mut self, destination_handle: i32) {
+    fn managed_get_original_caller_addr(&self, destination_handle: i32) {
         println!("Called: managed_get_original_caller_addr");
     }
 
-    fn managed_get_relayer_addr(&mut self, destination_handle: i32) {
+    fn managed_get_relayer_addr(&self, destination_handle: i32) {
         println!("Called: managed_get_relayer_addr");
     }
 
-    fn managed_signal_error(&mut self, err_handle: i32) {
+    fn managed_signal_error(&self, err_handle: i32) {
         println!("Called: managed_signal_error");
     }
 
-    fn managed_write_log(&mut self, topics_handle: i32, data_handle: i32) {
+    fn managed_write_log(&self, topics_handle: i32, data_handle: i32) {
         println!("Called: managed_write_log");
     }
 
-    fn managed_get_original_tx_hash(&mut self, result_handle: i32) {
+    fn managed_get_original_tx_hash(&self, result_handle: i32) {
         println!("Called: managed_get_original_tx_hash");
     }
 
-    fn managed_get_state_root_hash(&mut self, result_handle: i32) {
+    fn managed_get_state_root_hash(&self, result_handle: i32) {
         println!("Called: managed_get_state_root_hash");
     }
 
-    fn managed_get_block_random_seed(&mut self, result_handle: i32) {
+    fn managed_get_block_random_seed(&self, result_handle: i32) {
         println!("Called: managed_get_block_random_seed");
     }
 
-    fn managed_get_prev_block_random_seed(&mut self, result_handle: i32) {
+    fn managed_get_prev_block_random_seed(&self, result_handle: i32) {
         println!("Called: managed_get_prev_block_random_seed");
     }
 
-    fn managed_get_return_data(&mut self, result_id: i32, result_handle: i32) {
+    fn managed_get_return_data(&self, result_id: i32, result_handle: i32) {
         println!("Called: managed_get_return_data");
     }
 
-    fn managed_get_multi_esdt_call_value(&mut self, multi_call_value_handle: i32) {
+    fn managed_get_multi_esdt_call_value(&self, multi_call_value_handle: i32) {
         println!("Called: managed_get_multi_esdt_call_value");
     }
 
-    fn managed_get_back_transfers(&mut self, esdt_transfers_value_handle: i32, egld_value_handle: i32) {
+    fn managed_get_back_transfers(&self, esdt_transfers_value_handle: i32, egld_value_handle: i32) {
         println!("Called: managed_get_back_transfers");
     }
 
-    fn managed_get_esdt_balance(&mut self, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32) {
+    fn managed_get_esdt_balance(&self, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32) {
         println!("Called: managed_get_esdt_balance");
     }
 
-    fn managed_get_esdt_token_data(&mut self, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32, properties_handle: i32, hash_handle: i32, name_handle: i32, attributes_handle: i32, creator_handle: i32, royalties_handle: i32, uris_handle: i32) {
+    fn managed_get_esdt_token_data(&self, address_handle: i32, token_id_handle: i32, nonce: i64, value_handle: i32, properties_handle: i32, hash_handle: i32, name_handle: i32, attributes_handle: i32, creator_handle: i32, royalties_handle: i32, uris_handle: i32) {
         println!("Called: managed_get_esdt_token_data");
     }
 
-    fn managed_async_call(&mut self, dest_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32) {
+    fn managed_async_call(&self, dest_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32) {
         println!("Called: managed_async_call");
     }
 
-    fn managed_create_async_call(&mut self, dest_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, success_offset: MemPtr, success_length: MemLength, error_offset: MemPtr, error_length: MemLength, gas: i64, extra_gas_for_callback: i64, callback_closure_handle: i32) -> i32 {
+    fn managed_create_async_call(&self, dest_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, success_offset: MemPtr, success_length: MemLength, error_offset: MemPtr, error_length: MemLength, gas: i64, extra_gas_for_callback: i64, callback_closure_handle: i32) -> i32 {
         println!("Called: managed_create_async_call");
         0
     }
 
-    fn managed_get_callback_closure(&mut self, callback_closure_handle: i32) {
+    fn managed_get_callback_closure(&self, callback_closure_handle: i32) {
         println!("Called: managed_get_callback_closure");
     }
 
-    fn managed_upgrade_from_source_contract(&mut self, dest_handle: i32, gas: i64, value_handle: i32, address_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_handle: i32) {
+    fn managed_upgrade_from_source_contract(&self, dest_handle: i32, gas: i64, value_handle: i32, address_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_handle: i32) {
         println!("Called: managed_upgrade_from_source_contract");
     }
 
-    fn managed_upgrade_contract(&mut self, dest_handle: i32, gas: i64, value_handle: i32, code_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_handle: i32) {
+    fn managed_upgrade_contract(&self, dest_handle: i32, gas: i64, value_handle: i32, code_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_handle: i32) {
         println!("Called: managed_upgrade_contract");
     }
 
-    fn managed_delete_contract(&mut self, dest_handle: i32, gas_limit: i64, arguments_handle: i32) {
+    fn managed_delete_contract(&self, dest_handle: i32, gas_limit: i64, arguments_handle: i32) {
         println!("Called: managed_delete_contract");
     }
 
-    fn managed_deploy_from_source_contract(&mut self, gas: i64, value_handle: i32, address_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_address_handle: i32, result_handle: i32) -> i32 {
+    fn managed_deploy_from_source_contract(&self, gas: i64, value_handle: i32, address_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_address_handle: i32, result_handle: i32) -> i32 {
         println!("Called: managed_deploy_from_source_contract");
         0
     }
 
-    fn managed_create_contract(&mut self, gas: i64, value_handle: i32, code_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_address_handle: i32, result_handle: i32) -> i32 {
+    fn managed_create_contract(&self, gas: i64, value_handle: i32, code_handle: i32, code_metadata_handle: i32, arguments_handle: i32, result_address_handle: i32, result_handle: i32) -> i32 {
         println!("Called: managed_create_contract");
         0
     }
 
-    fn managed_execute_read_only(&mut self, gas: i64, address_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
+    fn managed_execute_read_only(&self, gas: i64, address_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
         println!("Called: managed_execute_read_only");
         0
     }
 
-    fn managed_execute_on_same_context(&mut self, gas: i64, address_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
+    fn managed_execute_on_same_context(&self, gas: i64, address_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
         println!("Called: managed_execute_on_same_context");
         0
     }
 
-    fn managed_execute_on_dest_context(&mut self, gas: i64, address_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
+    fn managed_execute_on_dest_context(&self, gas: i64, address_handle: i32, value_handle: i32, function_handle: i32, arguments_handle: i32, result_handle: i32) -> i32 {
         println!("Called: managed_execute_on_dest_context");
         0
     }
 
-    fn managed_multi_transfer_esdt_nft_execute(&mut self, dst_handle: i32, token_transfers_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
+    fn managed_multi_transfer_esdt_nft_execute(&self, dst_handle: i32, token_transfers_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
         println!("Called: managed_multi_transfer_esdt_nft_execute");
         0
     }
 
-    fn managed_multi_transfer_esdt_nft_execute_by_user(&mut self, user_handle: i32, dst_handle: i32, token_transfers_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
+    fn managed_multi_transfer_esdt_nft_execute_by_user(&self, user_handle: i32, dst_handle: i32, token_transfers_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
         println!("Called: managed_multi_transfer_esdt_nft_execute_by_user");
         0
     }
 
-    fn managed_transfer_value_execute(&mut self, dst_handle: i32, value_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
+    fn managed_transfer_value_execute(&self, dst_handle: i32, value_handle: i32, gas_limit: i64, function_handle: i32, arguments_handle: i32) -> i32 {
         println!("Called: managed_transfer_value_execute");
         0
     }
 
-    fn managed_is_esdt_frozen(&mut self, address_handle: i32, token_id_handle: i32, nonce: i64) -> i32 {
+    fn managed_is_esdt_frozen(&self, address_handle: i32, token_id_handle: i32, nonce: i64) -> i32 {
         println!("Called: managed_is_esdt_frozen");
         0
     }
 
-    fn managed_is_esdt_limited_transfer(&mut self, token_id_handle: i32) -> i32 {
+    fn managed_is_esdt_limited_transfer(&self, token_id_handle: i32) -> i32 {
         println!("Called: managed_is_esdt_limited_transfer");
         0
     }
 
-    fn managed_is_esdt_paused(&mut self, token_id_handle: i32) -> i32 {
+    fn managed_is_esdt_paused(&self, token_id_handle: i32) -> i32 {
         println!("Called: managed_is_esdt_paused");
         0
     }
 
-    fn managed_buffer_to_hex(&mut self, source_handle: i32, dest_handle: i32) {
+    fn managed_buffer_to_hex(&self, source_handle: i32, dest_handle: i32) {
         println!("Called: managed_buffer_to_hex");
     }
 
-    fn managed_get_code_metadata(&mut self, address_handle: i32, response_handle: i32) {
+    fn managed_get_code_metadata(&self, address_handle: i32, response_handle: i32) {
         println!("Called: managed_get_code_metadata");
     }
 
-    fn managed_is_builtin_function(&mut self, function_name_handle: i32) -> i32 {
+    fn managed_is_builtin_function(&self, function_name_handle: i32) -> i32 {
         println!("Called: managed_is_builtin_function");
         0
     }
 
-    fn big_float_new_from_parts(&mut self, integral_part: i32, fractional_part: i32, exponent: i32) -> i32 {
+    fn big_float_new_from_parts(&self, integral_part: i32, fractional_part: i32, exponent: i32) -> i32 {
         println!("Called: big_float_new_from_parts");
         0
     }
 
-    fn big_float_new_from_frac(&mut self, numerator: i64, denominator: i64) -> i32 {
+    fn big_float_new_from_frac(&self, numerator: i64, denominator: i64) -> i32 {
         println!("Called: big_float_new_from_frac");
         0
     }
 
-    fn big_float_new_from_sci(&mut self, significand: i64, exponent: i64) -> i32 {
+    fn big_float_new_from_sci(&self, significand: i64, exponent: i64) -> i32 {
         println!("Called: big_float_new_from_sci");
         0
     }
 
-    fn big_float_add(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_float_add(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         println!("Called: big_float_add");
     }
 
-    fn big_float_sub(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_float_sub(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         println!("Called: big_float_sub");
     }
 
-    fn big_float_mul(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_float_mul(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         println!("Called: big_float_mul");
     }
 
-    fn big_float_div(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_float_div(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         println!("Called: big_float_div");
     }
 
-    fn big_float_neg(&mut self, destination_handle: i32, op_handle: i32) {
+    fn big_float_neg(&self, destination_handle: i32, op_handle: i32) {
         println!("Called: big_float_neg");
     }
 
-    fn big_float_clone(&mut self, destination_handle: i32, op_handle: i32) {
+    fn big_float_clone(&self, destination_handle: i32, op_handle: i32) {
         println!("Called: big_float_clone");
     }
 
-    fn big_float_cmp(&mut self, op1_handle: i32, op2_handle: i32) -> i32 {
+    fn big_float_cmp(&self, op1_handle: i32, op2_handle: i32) -> i32 {
         println!("Called: big_float_cmp");
         0
     }
 
-    fn big_float_abs(&mut self, destination_handle: i32, op_handle: i32) {
+    fn big_float_abs(&self, destination_handle: i32, op_handle: i32) {
         println!("Called: big_float_abs");
     }
 
-    fn big_float_sign(&mut self, op_handle: i32) -> i32 {
+    fn big_float_sign(&self, op_handle: i32) -> i32 {
         println!("Called: big_float_sign");
         0
     }
 
-    fn big_float_sqrt(&mut self, destination_handle: i32, op_handle: i32) {
+    fn big_float_sqrt(&self, destination_handle: i32, op_handle: i32) {
         println!("Called: big_float_sqrt");
     }
 
-    fn big_float_pow(&mut self, destination_handle: i32, op_handle: i32, exponent: i32) {
+    fn big_float_pow(&self, destination_handle: i32, op_handle: i32, exponent: i32) {
         println!("Called: big_float_pow");
     }
 
-    fn big_float_floor(&mut self, dest_big_int_handle: i32, op_handle: i32) {
+    fn big_float_floor(&self, dest_big_int_handle: i32, op_handle: i32) {
         println!("Called: big_float_floor");
     }
 
-    fn big_float_ceil(&mut self, dest_big_int_handle: i32, op_handle: i32) {
+    fn big_float_ceil(&self, dest_big_int_handle: i32, op_handle: i32) {
         println!("Called: big_float_ceil");
     }
 
-    fn big_float_truncate(&mut self, dest_big_int_handle: i32, op_handle: i32) {
+    fn big_float_truncate(&self, dest_big_int_handle: i32, op_handle: i32) {
         println!("Called: big_float_truncate");
     }
 
-    fn big_float_set_int64(&mut self, destination_handle: i32, value: i64) {
+    fn big_float_set_int64(&self, destination_handle: i32, value: i64) {
         println!("Called: big_float_set_int64");
     }
 
-    fn big_float_is_int(&mut self, op_handle: i32) -> i32 {
+    fn big_float_is_int(&self, op_handle: i32) -> i32 {
         println!("Called: big_float_is_int");
         0
     }
 
-    fn big_float_set_big_int(&mut self, destination_handle: i32, big_int_handle: i32) {
+    fn big_float_set_big_int(&self, destination_handle: i32, big_int_handle: i32) {
         println!("Called: big_float_set_big_int");
     }
 
-    fn big_float_get_const_pi(&mut self, destination_handle: i32) {
+    fn big_float_get_const_pi(&self, destination_handle: i32) {
         println!("Called: big_float_get_const_pi");
     }
 
-    fn big_float_get_const_e(&mut self, destination_handle: i32) {
+    fn big_float_get_const_e(&self, destination_handle: i32) {
         println!("Called: big_float_get_const_e");
     }
 
-    fn big_int_get_unsigned_argument(&mut self, id: i32, destination_handle: i32) {
+    fn big_int_get_unsigned_argument(&self, id: i32, destination_handle: i32) {
         println!("Called: big_int_get_unsigned_argument");
     }
 
-    fn big_int_get_signed_argument(&mut self, id: i32, destination_handle: i32) {
+    fn big_int_get_signed_argument(&self, id: i32, destination_handle: i32) {
         println!("Called: big_int_get_signed_argument");
     }
 
-    fn big_int_storage_store_unsigned(&mut self, key_offset: MemPtr, key_length: MemLength, source_handle: i32) -> i32 {
+    fn big_int_storage_store_unsigned(&self, key_offset: MemPtr, key_length: MemLength, source_handle: i32) -> i32 {
         println!("Called: big_int_storage_store_unsigned");
         0
     }
 
-    fn big_int_storage_load_unsigned(&mut self, key_offset: MemPtr, key_length: MemLength, destination_handle: i32) -> i32 {
+    fn big_int_storage_load_unsigned(&self, key_offset: MemPtr, key_length: MemLength, destination_handle: i32) -> i32 {
         println!("Called: big_int_storage_load_unsigned");
         0
     }
 
-    fn big_int_get_call_value(&mut self, destination_handle: i32) {
+    fn big_int_get_call_value(&self, destination_handle: i32) {
         println!("Called: big_int_get_call_value");
     }
 
-    fn big_int_get_esdt_call_value(&mut self, destination: i32) {
+    fn big_int_get_esdt_call_value(&self, destination: i32) {
         println!("Called: big_int_get_esdt_call_value");
     }
 
-    fn big_int_get_esdt_call_value_by_index(&mut self, destination_handle: i32, index: i32) {
+    fn big_int_get_esdt_call_value_by_index(&self, destination_handle: i32, index: i32) {
         println!("Called: big_int_get_esdt_call_value_by_index");
     }
 
-    fn big_int_get_external_balance(&mut self, address_offset: MemPtr, result: i32) {
+    fn big_int_get_external_balance(&self, address_offset: MemPtr, result: i32) {
         println!("Called: big_int_get_external_balance");
     }
 
-    fn big_int_get_esdt_external_balance(&mut self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, result_handle: i32) {
+    fn big_int_get_esdt_external_balance(&self, address_offset: MemPtr, token_id_offset: MemPtr, token_id_len: MemLength, nonce: i64, result_handle: i32) {
         println!("Called: big_int_get_esdt_external_balance");
     }
 
-    fn big_int_new(&mut self, small_value: i64) -> i32 {
+    fn big_int_new(&self, small_value: i64) -> i32 {
         println!("Called: big_int_new");
         0
     }
 
-    fn big_int_unsigned_byte_length(&mut self, reference_handle: i32) -> i32 {
+    fn big_int_unsigned_byte_length(&self, reference_handle: i32) -> i32 {
         println!("Called: big_int_unsigned_byte_length");
         0
     }
 
-    fn big_int_signed_byte_length(&mut self, reference_handle: i32) -> i32 {
+    fn big_int_signed_byte_length(&self, reference_handle: i32) -> i32 {
         println!("Called: big_int_signed_byte_length");
         0
     }
 
-    fn big_int_get_unsigned_bytes(&mut self, reference_handle: i32, byte_offset: MemPtr) -> i32 {
+    fn big_int_get_unsigned_bytes(&self, reference_handle: i32, byte_offset: MemPtr) -> i32 {
         println!("Called: big_int_get_unsigned_bytes");
         0
     }
 
-    fn big_int_get_signed_bytes(&mut self, reference_handle: i32, byte_offset: MemPtr) -> i32 {
+    fn big_int_get_signed_bytes(&self, reference_handle: i32, byte_offset: MemPtr) -> i32 {
         println!("Called: big_int_get_signed_bytes");
         0
     }
 
-    fn big_int_set_unsigned_bytes(&mut self, destination_handle: i32, byte_offset: MemPtr, byte_length: MemLength) {
+    fn big_int_set_unsigned_bytes(&self, destination_handle: i32, byte_offset: MemPtr, byte_length: MemLength) {
         println!("Called: big_int_set_unsigned_bytes");
     }
 
-    fn big_int_set_signed_bytes(&mut self, destination_handle: i32, byte_offset: MemPtr, byte_length: MemLength) {
+    fn big_int_set_signed_bytes(&self, destination_handle: i32, byte_offset: MemPtr, byte_length: MemLength) {
         println!("Called: big_int_set_signed_bytes");
     }
 
-    fn big_int_is_int64(&mut self, destination_handle: i32) -> i32 {
+    fn big_int_is_int64(&self, destination_handle: i32) -> i32 {
         println!("Called: big_int_is_int64");
         0
     }
 
-    fn big_int_get_int64(&mut self, destination_handle: i32) -> i64 {
+    fn big_int_get_int64(&self, destination_handle: i32) -> i64 {
         println!("Called: big_int_get_int64");
         0
     }
 
-    fn big_int_set_int64(&mut self, destination_handle: i32, value: i64) {
+    fn big_int_set_int64(&self, destination_handle: i32, value: i64) {
         println!("Called: big_int_set_int64");
     }
 
-    fn big_int_add(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_add(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         println!("Called: big_int_add");
     }
 
-    fn big_int_sub(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_sub(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         println!("Called: big_int_sub");
     }
 
-    fn big_int_mul(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_mul(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         println!("Called: big_int_mul");
     }
 
-    fn big_int_tdiv(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_tdiv(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         println!("Called: big_int_tdiv");
     }
 
-    fn big_int_tmod(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_tmod(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         println!("Called: big_int_tmod");
     }
 
-    fn big_int_ediv(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_ediv(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         println!("Called: big_int_ediv");
     }
 
-    fn big_int_emod(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_emod(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         println!("Called: big_int_emod");
     }
 
-    fn big_int_sqrt(&mut self, destination_handle: i32, op_handle: i32) {
+    fn big_int_sqrt(&self, destination_handle: i32, op_handle: i32) {
         println!("Called: big_int_sqrt");
     }
 
-    fn big_int_pow(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_pow(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         println!("Called: big_int_pow");
     }
 
-    fn big_int_log2(&mut self, op1_handle: i32) -> i32 {
+    fn big_int_log2(&self, op1_handle: i32) -> i32 {
         println!("Called: big_int_log2");
         0
     }
 
-    fn big_int_abs(&mut self, destination_handle: i32, op_handle: i32) {
+    fn big_int_abs(&self, destination_handle: i32, op_handle: i32) {
         println!("Called: big_int_abs");
     }
 
-    fn big_int_neg(&mut self, destination_handle: i32, op_handle: i32) {
+    fn big_int_neg(&self, destination_handle: i32, op_handle: i32) {
         println!("Called: big_int_neg");
     }
 
-    fn big_int_sign(&mut self, op_handle: i32) -> i32 {
+    fn big_int_sign(&self, op_handle: i32) -> i32 {
         println!("Called: big_int_sign");
         0
     }
 
-    fn big_int_cmp(&mut self, op1_handle: i32, op2_handle: i32) -> i32 {
+    fn big_int_cmp(&self, op1_handle: i32, op2_handle: i32) -> i32 {
         println!("Called: big_int_cmp");
         0
     }
 
-    fn big_int_not(&mut self, destination_handle: i32, op_handle: i32) {
+    fn big_int_not(&self, destination_handle: i32, op_handle: i32) {
         println!("Called: big_int_not");
     }
 
-    fn big_int_and(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_and(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         println!("Called: big_int_and");
     }
 
-    fn big_int_or(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_or(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         println!("Called: big_int_or");
     }
 
-    fn big_int_xor(&mut self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
+    fn big_int_xor(&self, destination_handle: i32, op1_handle: i32, op2_handle: i32) {
         println!("Called: big_int_xor");
     }
 
-    fn big_int_shr(&mut self, destination_handle: i32, op_handle: i32, bits: i32) {
+    fn big_int_shr(&self, destination_handle: i32, op_handle: i32, bits: i32) {
         println!("Called: big_int_shr");
     }
 
-    fn big_int_shl(&mut self, destination_handle: i32, op_handle: i32, bits: i32) {
+    fn big_int_shl(&self, destination_handle: i32, op_handle: i32, bits: i32) {
         println!("Called: big_int_shl");
     }
 
-    fn big_int_finish_unsigned(&mut self, reference_handle: i32) {
+    fn big_int_finish_unsigned(&self, reference_handle: i32) {
         println!("Called: big_int_finish_unsigned");
     }
 
-    fn big_int_finish_signed(&mut self, reference_handle: i32) {
+    fn big_int_finish_signed(&self, reference_handle: i32) {
         println!("Called: big_int_finish_signed");
     }
 
-    fn big_int_to_string(&mut self, big_int_handle: i32, destination_handle: i32) {
+    fn big_int_to_string(&self, big_int_handle: i32, destination_handle: i32) {
         println!("Called: big_int_to_string");
     }
 
-    fn mbuffer_new(&mut self) -> i32 {
+    fn mbuffer_new(&self) -> i32 {
         println!("Called: mbuffer_new");
         0
     }
 
-    fn mbuffer_new_from_bytes(&mut self, data_offset: MemPtr, data_length: MemLength) -> i32 {
+    fn mbuffer_new_from_bytes(&self, data_offset: MemPtr, data_length: MemLength) -> i32 {
         println!("Called: mbuffer_new_from_bytes");
         0
     }
 
-    fn mbuffer_get_length(&mut self, m_buffer_handle: i32) -> i32 {
+    fn mbuffer_get_length(&self, m_buffer_handle: i32) -> i32 {
         println!("Called: mbuffer_get_length");
         0
     }
 
-    fn mbuffer_get_bytes(&mut self, m_buffer_handle: i32, result_offset: MemPtr) -> i32 {
+    fn mbuffer_get_bytes(&self, m_buffer_handle: i32, result_offset: MemPtr) -> i32 {
         println!("Called: mbuffer_get_bytes");
         0
     }
 
-    fn mbuffer_get_byte_slice(&mut self, source_handle: i32, starting_position: i32, slice_length: i32, result_offset: MemPtr) -> i32 {
+    fn mbuffer_get_byte_slice(&self, source_handle: i32, starting_position: i32, slice_length: i32, result_offset: MemPtr) -> i32 {
         println!("Called: mbuffer_get_byte_slice");
         0
     }
 
-    fn mbuffer_copy_byte_slice(&mut self, source_handle: i32, starting_position: i32, slice_length: i32, destination_handle: i32) -> i32 {
+    fn mbuffer_copy_byte_slice(&self, source_handle: i32, starting_position: i32, slice_length: i32, destination_handle: i32) -> i32 {
         println!("Called: mbuffer_copy_byte_slice");
         0
     }
 
-    fn mbuffer_eq(&mut self, m_buffer_handle1: i32, m_buffer_handle2: i32) -> i32 {
+    fn mbuffer_eq(&self, m_buffer_handle1: i32, m_buffer_handle2: i32) -> i32 {
         println!("Called: mbuffer_eq");
         0
     }
 
-    fn mbuffer_set_bytes(&mut self, m_buffer_handle: i32, data_offset: MemPtr, data_length: MemLength) -> i32 {
+    fn mbuffer_set_bytes(&self, m_buffer_handle: i32, data_offset: MemPtr, data_length: MemLength) -> i32 {
         println!("Called: mbuffer_set_bytes");
         0
     }
 
-    fn mbuffer_set_byte_slice(&mut self, m_buffer_handle: i32, starting_position: i32, data_length: MemLength, data_offset: MemPtr) -> i32 {
+    fn mbuffer_set_byte_slice(&self, m_buffer_handle: i32, starting_position: i32, data_length: MemLength, data_offset: MemPtr) -> i32 {
         println!("Called: mbuffer_set_byte_slice");
         0
     }
 
-    fn mbuffer_append(&mut self, accumulator_handle: i32, data_handle: i32) -> i32 {
+    fn mbuffer_append(&self, accumulator_handle: i32, data_handle: i32) -> i32 {
         println!("Called: mbuffer_append");
         0
     }
 
-    fn mbuffer_append_bytes(&mut self, accumulator_handle: i32, data_offset: MemPtr, data_length: MemLength) -> i32 {
+    fn mbuffer_append_bytes(&self, accumulator_handle: i32, data_offset: MemPtr, data_length: MemLength) -> i32 {
         println!("Called: mbuffer_append_bytes");
         0
     }
 
-    fn mbuffer_to_big_int_unsigned(&mut self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
+    fn mbuffer_to_big_int_unsigned(&self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
         println!("Called: mbuffer_to_big_int_unsigned");
         0
     }
 
-    fn mbuffer_to_big_int_signed(&mut self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
+    fn mbuffer_to_big_int_signed(&self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
         println!("Called: mbuffer_to_big_int_signed");
         0
     }
 
-    fn mbuffer_from_big_int_unsigned(&mut self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
+    fn mbuffer_from_big_int_unsigned(&self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
         println!("Called: mbuffer_from_big_int_unsigned");
         0
     }
 
-    fn mbuffer_from_big_int_signed(&mut self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
+    fn mbuffer_from_big_int_signed(&self, m_buffer_handle: i32, big_int_handle: i32) -> i32 {
         println!("Called: mbuffer_from_big_int_signed");
         0
     }
 
-    fn mbuffer_to_big_float(&mut self, m_buffer_handle: i32, big_float_handle: i32) -> i32 {
+    fn mbuffer_to_big_float(&self, m_buffer_handle: i32, big_float_handle: i32) -> i32 {
         println!("Called: mbuffer_to_big_float");
         0
     }
 
-    fn mbuffer_from_big_float(&mut self, m_buffer_handle: i32, big_float_handle: i32) -> i32 {
+    fn mbuffer_from_big_float(&self, m_buffer_handle: i32, big_float_handle: i32) -> i32 {
         println!("Called: mbuffer_from_big_float");
         0
     }
 
-    fn mbuffer_storage_store(&mut self, key_handle: i32, source_handle: i32) -> i32 {
+    fn mbuffer_storage_store(&self, key_handle: i32, source_handle: i32) -> i32 {
         println!("Called: mbuffer_storage_store");
         0
     }
 
-    fn mbuffer_storage_load(&mut self, key_handle: i32, destination_handle: i32) -> i32 {
+    fn mbuffer_storage_load(&self, key_handle: i32, destination_handle: i32) -> i32 {
         println!("Called: mbuffer_storage_load");
         0
     }
 
-    fn mbuffer_storage_load_from_address(&mut self, address_handle: i32, key_handle: i32, destination_handle: i32) {
+    fn mbuffer_storage_load_from_address(&self, address_handle: i32, key_handle: i32, destination_handle: i32) {
         println!("Called: mbuffer_storage_load_from_address");
     }
 
-    fn mbuffer_get_argument(&mut self, id: i32, destination_handle: i32) -> i32 {
+    fn mbuffer_get_argument(&self, id: i32, destination_handle: i32) -> i32 {
         println!("Called: mbuffer_get_argument");
         0
     }
 
-    fn mbuffer_finish(&mut self, source_handle: i32) -> i32 {
+    fn mbuffer_finish(&self, source_handle: i32) -> i32 {
         println!("Called: mbuffer_finish");
         0
     }
 
-    fn mbuffer_set_random(&mut self, destination_handle: i32, length: i32) -> i32 {
+    fn mbuffer_set_random(&self, destination_handle: i32, length: i32) -> i32 {
         println!("Called: mbuffer_set_random");
         0
     }
 
-    fn managed_map_new(&mut self) -> i32 {
+    fn managed_map_new(&self) -> i32 {
         println!("Called: managed_map_new");
         0
     }
 
-    fn managed_map_put(&mut self, m_map_handle: i32, key_handle: i32, value_handle: i32) -> i32 {
+    fn managed_map_put(&self, m_map_handle: i32, key_handle: i32, value_handle: i32) -> i32 {
         println!("Called: managed_map_put");
         0
     }
 
-    fn managed_map_get(&mut self, m_map_handle: i32, key_handle: i32, out_value_handle: i32) -> i32 {
+    fn managed_map_get(&self, m_map_handle: i32, key_handle: i32, out_value_handle: i32) -> i32 {
         println!("Called: managed_map_get");
         0
     }
 
-    fn managed_map_remove(&mut self, m_map_handle: i32, key_handle: i32, out_value_handle: i32) -> i32 {
+    fn managed_map_remove(&self, m_map_handle: i32, key_handle: i32, out_value_handle: i32) -> i32 {
         println!("Called: managed_map_remove");
         0
     }
 
-    fn managed_map_contains(&mut self, m_map_handle: i32, key_handle: i32) -> i32 {
+    fn managed_map_contains(&self, m_map_handle: i32, key_handle: i32) -> i32 {
         println!("Called: managed_map_contains");
         0
     }
 
-    fn small_int_get_unsigned_argument(&mut self, id: i32) -> i64 {
+    fn small_int_get_unsigned_argument(&self, id: i32) -> i64 {
         println!("Called: small_int_get_unsigned_argument");
         0
     }
 
-    fn small_int_get_signed_argument(&mut self, id: i32) -> i64 {
+    fn small_int_get_signed_argument(&self, id: i32) -> i64 {
         println!("Called: small_int_get_signed_argument");
         0
     }
 
-    fn small_int_finish_unsigned(&mut self, value: i64) {
+    fn small_int_finish_unsigned(&self, value: i64) {
         println!("Called: small_int_finish_unsigned");
     }
 
-    fn small_int_finish_signed(&mut self, value: i64) {
+    fn small_int_finish_signed(&self, value: i64) {
         println!("Called: small_int_finish_signed");
     }
 
-    fn small_int_storage_store_unsigned(&mut self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32 {
+    fn small_int_storage_store_unsigned(&self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32 {
         println!("Called: small_int_storage_store_unsigned");
         0
     }
 
-    fn small_int_storage_store_signed(&mut self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32 {
+    fn small_int_storage_store_signed(&self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32 {
         println!("Called: small_int_storage_store_signed");
         0
     }
 
-    fn small_int_storage_load_unsigned(&mut self, key_offset: MemPtr, key_length: MemLength) -> i64 {
+    fn small_int_storage_load_unsigned(&self, key_offset: MemPtr, key_length: MemLength) -> i64 {
         println!("Called: small_int_storage_load_unsigned");
         0
     }
 
-    fn small_int_storage_load_signed(&mut self, key_offset: MemPtr, key_length: MemLength) -> i64 {
+    fn small_int_storage_load_signed(&self, key_offset: MemPtr, key_length: MemLength) -> i64 {
         println!("Called: small_int_storage_load_signed");
         0
     }
 
-    fn int64get_argument(&mut self, id: i32) -> i64 {
+    fn int64get_argument(&self, id: i32) -> i64 {
         println!("Called: int64get_argument");
         0
     }
 
-    fn int64finish(&mut self, value: i64) {
+    fn int64finish(&self, value: i64) {
         println!("Called: int64finish");
     }
 
-    fn int64storage_store(&mut self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32 {
+    fn int64storage_store(&self, key_offset: MemPtr, key_length: MemLength, value: i64) -> i32 {
         println!("Called: int64storage_store");
         0
     }
 
-    fn int64storage_load(&mut self, key_offset: MemPtr, key_length: MemLength) -> i64 {
+    fn int64storage_load(&self, key_offset: MemPtr, key_length: MemLength) -> i64 {
         println!("Called: int64storage_load");
         0
     }
 
-    fn sha256(&mut self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32 {
+    fn sha256(&self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32 {
         println!("Called: sha256");
         0
     }
 
-    fn managed_sha256(&mut self, input_handle: i32, output_handle: i32) -> i32 {
+    fn managed_sha256(&self, input_handle: i32, output_handle: i32) -> i32 {
         println!("Called: managed_sha256");
         0
     }
 
-    fn keccak256(&mut self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32 {
+    fn keccak256(&self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32 {
         println!("Called: keccak256");
         0
     }
 
-    fn managed_keccak256(&mut self, input_handle: i32, output_handle: i32) -> i32 {
+    fn managed_keccak256(&self, input_handle: i32, output_handle: i32) -> i32 {
         println!("Called: managed_keccak256");
         0
     }
 
-    fn ripemd160(&mut self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32 {
+    fn ripemd160(&self, data_offset: MemPtr, length: MemLength, result_offset: MemPtr) -> i32 {
         println!("Called: ripemd160");
         0
     }
 
-    fn managed_ripemd160(&mut self, input_handle: i32, output_handle: i32) -> i32 {
+    fn managed_ripemd160(&self, input_handle: i32, output_handle: i32) -> i32 {
         println!("Called: managed_ripemd160");
         0
     }
 
-    fn verify_bls(&mut self, key_offset: MemPtr, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32 {
+    fn verify_bls(&self, key_offset: MemPtr, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32 {
         println!("Called: verify_bls");
         0
     }
 
-    fn managed_verify_bls(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
+    fn managed_verify_bls(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
         println!("Called: managed_verify_bls");
         0
     }
 
-    fn verify_ed25519(&mut self, key_offset: MemPtr, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32 {
+    fn verify_ed25519(&self, key_offset: MemPtr, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32 {
         println!("Called: verify_ed25519");
         0
     }
 
-    fn managed_verify_ed25519(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
+    fn managed_verify_ed25519(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
         println!("Called: managed_verify_ed25519");
         0
     }
 
-    fn verify_custom_secp256k1(&mut self, key_offset: MemPtr, key_length: MemLength, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr, hash_type: i32) -> i32 {
+    fn verify_custom_secp256k1(&self, key_offset: MemPtr, key_length: MemLength, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr, hash_type: i32) -> i32 {
         println!("Called: verify_custom_secp256k1");
         0
     }
 
-    fn managed_verify_custom_secp256k1(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32, hash_type: i32) -> i32 {
+    fn managed_verify_custom_secp256k1(&self, key_handle: i32, message_handle: i32, sig_handle: i32, hash_type: i32) -> i32 {
         println!("Called: managed_verify_custom_secp256k1");
         0
     }
 
-    fn verify_secp256k1(&mut self, key_offset: MemPtr, key_length: MemLength, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32 {
+    fn verify_secp256k1(&self, key_offset: MemPtr, key_length: MemLength, message_offset: MemPtr, message_length: MemLength, sig_offset: MemPtr) -> i32 {
         println!("Called: verify_secp256k1");
         0
     }
 
-    fn managed_verify_secp256k1(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
+    fn managed_verify_secp256k1(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
         println!("Called: managed_verify_secp256k1");
         0
     }
 
-    fn encode_secp256k1_der_signature(&mut self, r_offset: MemPtr, r_length: MemLength, s_offset: MemPtr, s_length: MemLength, sig_offset: MemPtr) -> i32 {
+    fn encode_secp256k1_der_signature(&self, r_offset: MemPtr, r_length: MemLength, s_offset: MemPtr, s_length: MemLength, sig_offset: MemPtr) -> i32 {
         println!("Called: encode_secp256k1_der_signature");
         0
     }
 
-    fn managed_encode_secp256k1_der_signature(&mut self, r_handle: i32, s_handle: i32, sig_handle: i32) -> i32 {
+    fn managed_encode_secp256k1_der_signature(&self, r_handle: i32, s_handle: i32, sig_handle: i32) -> i32 {
         println!("Called: managed_encode_secp256k1_der_signature");
         0
     }
 
-    fn add_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, fst_point_xhandle: i32, fst_point_yhandle: i32, snd_point_xhandle: i32, snd_point_yhandle: i32) {
+    fn add_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, fst_point_xhandle: i32, fst_point_yhandle: i32, snd_point_xhandle: i32, snd_point_yhandle: i32) {
         println!("Called: add_ec");
     }
 
-    fn double_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32) {
+    fn double_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32) {
         println!("Called: double_ec");
     }
 
-    fn is_on_curve_ec(&mut self, ec_handle: i32, point_xhandle: i32, point_yhandle: i32) -> i32 {
+    fn is_on_curve_ec(&self, ec_handle: i32, point_xhandle: i32, point_yhandle: i32) -> i32 {
         println!("Called: is_on_curve_ec");
         0
     }
 
-    fn scalar_base_mult_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
+    fn scalar_base_mult_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
         println!("Called: scalar_base_mult_ec");
         0
     }
 
-    fn managed_scalar_base_mult_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
+    fn managed_scalar_base_mult_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
         println!("Called: managed_scalar_base_mult_ec");
         0
     }
 
-    fn scalar_mult_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
+    fn scalar_mult_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
         println!("Called: scalar_mult_ec");
         0
     }
 
-    fn managed_scalar_mult_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32, data_handle: i32) -> i32 {
+    fn managed_scalar_mult_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, point_xhandle: i32, point_yhandle: i32, data_handle: i32) -> i32 {
         println!("Called: managed_scalar_mult_ec");
         0
     }
 
-    fn marshal_ec(&mut self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32 {
+    fn marshal_ec(&self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32 {
         println!("Called: marshal_ec");
         0
     }
 
-    fn managed_marshal_ec(&mut self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
+    fn managed_marshal_ec(&self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
         println!("Called: managed_marshal_ec");
         0
     }
 
-    fn marshal_compressed_ec(&mut self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32 {
+    fn marshal_compressed_ec(&self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32 {
         println!("Called: marshal_compressed_ec");
         0
     }
 
-    fn managed_marshal_compressed_ec(&mut self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
+    fn managed_marshal_compressed_ec(&self, x_pair_handle: i32, y_pair_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
         println!("Called: managed_marshal_compressed_ec");
         0
     }
 
-    fn unmarshal_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
+    fn unmarshal_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
         println!("Called: unmarshal_ec");
         0
     }
 
-    fn managed_unmarshal_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
+    fn managed_unmarshal_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
         println!("Called: managed_unmarshal_ec");
         0
     }
 
-    fn unmarshal_compressed_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
+    fn unmarshal_compressed_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_offset: MemPtr, length: MemLength) -> i32 {
         println!("Called: unmarshal_compressed_ec");
         0
     }
 
-    fn managed_unmarshal_compressed_ec(&mut self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
+    fn managed_unmarshal_compressed_ec(&self, x_result_handle: i32, y_result_handle: i32, ec_handle: i32, data_handle: i32) -> i32 {
         println!("Called: managed_unmarshal_compressed_ec");
         0
     }
 
-    fn generate_key_ec(&mut self, x_pub_key_handle: i32, y_pub_key_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32 {
+    fn generate_key_ec(&self, x_pub_key_handle: i32, y_pub_key_handle: i32, ec_handle: i32, result_offset: MemPtr) -> i32 {
         println!("Called: generate_key_ec");
         0
     }
 
-    fn managed_generate_key_ec(&mut self, x_pub_key_handle: i32, y_pub_key_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
+    fn managed_generate_key_ec(&self, x_pub_key_handle: i32, y_pub_key_handle: i32, ec_handle: i32, result_handle: i32) -> i32 {
         println!("Called: managed_generate_key_ec");
         0
     }
 
-    fn create_ec(&mut self, data_offset: MemPtr, data_length: MemLength) -> i32 {
+    fn create_ec(&self, data_offset: MemPtr, data_length: MemLength) -> i32 {
         println!("Called: create_ec");
         0
     }
 
-    fn managed_create_ec(&mut self, data_handle: i32) -> i32 {
+    fn managed_create_ec(&self, data_handle: i32) -> i32 {
         println!("Called: managed_create_ec");
         0
     }
 
-    fn get_curve_length_ec(&mut self, ec_handle: i32) -> i32 {
+    fn get_curve_length_ec(&self, ec_handle: i32) -> i32 {
         println!("Called: get_curve_length_ec");
         0
     }
 
-    fn get_priv_key_byte_length_ec(&mut self, ec_handle: i32) -> i32 {
+    fn get_priv_key_byte_length_ec(&self, ec_handle: i32) -> i32 {
         println!("Called: get_priv_key_byte_length_ec");
         0
     }
 
-    fn elliptic_curve_get_values(&mut self, ec_handle: i32, field_order_handle: i32, base_point_order_handle: i32, eq_constant_handle: i32, x_base_point_handle: i32, y_base_point_handle: i32) -> i32 {
+    fn elliptic_curve_get_values(&self, ec_handle: i32, field_order_handle: i32, base_point_order_handle: i32, eq_constant_handle: i32, x_base_point_handle: i32, y_base_point_handle: i32) -> i32 {
         println!("Called: elliptic_curve_get_values");
         0
     }
 
-    fn managed_verify_secp256r1(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
+    fn managed_verify_secp256r1(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
         println!("Called: managed_verify_secp256r1");
         0
     }
 
-    fn managed_verify_blssignature_share(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
+    fn managed_verify_blssignature_share(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
         println!("Called: managed_verify_blssignature_share");
         0
     }
 
-    fn managed_verify_blsaggregated_signature(&mut self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
+    fn managed_verify_blsaggregated_signature(&self, key_handle: i32, message_handle: i32, sig_handle: i32) -> i32 {
         println!("Called: managed_verify_blsaggregated_signature");
         0
     }


### PR DESCRIPTION
Almost completely reverted all changes to the legacy VM hooks, now that we have the new ones.

The adapter (new -> old) was made a struct instead of a trait (nesting is better than inheritance).